### PR TITLE
Finalize VTK UI refactor

### DIFF
--- a/FlexSimulate.pro
+++ b/FlexSimulate.pro
@@ -37,7 +37,10 @@ HEADERS += \
 FORMS += \
     MainWindow.ui \
     SchemeCardWidget.ui \
-    SchemeGalleryWidget.ui \
+    SchemeGalleryWidget.ui
+
+RESOURCES += \
+    resources.qrc
 
 
 # Default rules for deployment.

--- a/JsonPageBuilder.h
+++ b/JsonPageBuilder.h
@@ -13,7 +13,11 @@ class JsonPageBuilder : public QWidget
     Q_OBJECT
 public:
     explicit JsonPageBuilder(const QString& jsonPath,
-                           QWidget* parent = nullptr);
+                             QWidget* parent = nullptr);
+
+signals:
+    void logMessage(const QString& message);
+    void calculationFinished(const QString& stlPath);
 
 private slots:
     void onCalculateButtonClicked();

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -7,6 +7,7 @@
 #include <QPixmap>
 #include <QUrl>
 #include <QDir>
+#include <vtkSmartPointer.h>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -16,6 +17,10 @@ class QTreeWidgetItem;
 class QWidget;
 class QShortcut;
 class SchemeGalleryWidget;
+class JsonPageBuilder;
+class vtkGenericOpenGLRenderWindow;
+class vtkRenderer;
+class vtkActor;
 
 class MainWindow : public QMainWindow
 {
@@ -48,7 +53,7 @@ private:
     struct SchemeRecord {
         QString id;
         QString name;
-        QString directory;
+        QString workingDirectory;
         QVector<ModelRecord> models;
     };
 
@@ -78,13 +83,18 @@ private:
     QWidget* buildSchemeSettingsWidget(const SchemeRecord& scheme);
     QWidget* buildModelSettingsWidget(const ModelRecord& model);
     void refreshCurrentDetail();
+    void updateToolbarState();
+    void appendLogMessage(const QString& message);
+    void displayStlFile(const QString& filePath);
+    void clearVtkScene();
 
     SchemeRecord* schemeById(const QString& id);
     const SchemeRecord* schemeById(const QString& id) const;
-    SchemeRecord* schemeByDirectory(const QString& canonicalPath);
+    SchemeRecord* schemeByWorkingDirectory(const QString& canonicalPath);
     ModelRecord* modelById(const QString& id, SchemeRecord** owner = nullptr);
     const ModelRecord* modelById(const QString& id, const SchemeRecord** owner = nullptr) const;
 
+    QString createScheme(const QString& name, const QString& workingDir);
     QString importSchemeFromDirectory(const QString& dirPath, bool showError = true);
     QVector<QString> importModelsIntoScheme(const QString& schemeId,
                                             const QStringList& paths,
@@ -94,9 +104,15 @@ private:
     QPixmap makeSchemePlaceholder(const QString& name) const;
     void promptAddScheme();
     void promptAddModel(const QString& schemeId);
+    void openSchemeSettings(const QString& schemeId);
     void removeSchemeById(const QString& id);
     void removeModelById(const QString& id);
     void syncDataFromTree();
+    bool loadSchemesFromStorage();
+    void saveSchemesToStorage() const;
+    void persistSchemes() const;
+    QString makeUniqueWorkspaceSubdir(const QString& baseName) const;
+    QString workspaceRoot() const;
 
     Ui::MainWindow *ui;
     SchemeGalleryWidget* m_galleryWidget = nullptr;
@@ -107,4 +123,9 @@ private:
     QString m_activeSchemeId;
     QString m_activeModelId;
     bool m_blockTreeSignals = false;
+    QString m_storageFilePath;
+    QString m_workspaceRoot;
+    vtkSmartPointer<vtkGenericOpenGLRenderWindow> m_renderWindow;
+    vtkSmartPointer<vtkRenderer> m_renderer;
+    vtkSmartPointer<vtkActor> m_currentActor;
 };

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -6,48 +6,216 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1224</width>
-    <height>946</height>
+    <width>1320</width>
+    <height>920</height>
    </rect>
-  </property>
-  <property name="acceptDrops">
-   <bool>false</bool>
   </property>
   <property name="windowTitle">
    <string>柔性仿真软件</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_4">
+   <layout class="QVBoxLayout" name="mainLayout">
+    <property name="spacing">
+     <number>8</number>
+    </property>
+    <property name="leftMargin">
+     <number>12</number>
+    </property>
+    <property name="topMargin">
+     <number>12</number>
+    </property>
+    <property name="rightMargin">
+     <number>12</number>
+    </property>
+    <property name="bottomMargin">
+     <number>12</number>
+    </property>
     <item>
-     <widget class="QSplitter" name="splitter">
+     <widget class="QWidget" name="headerWidget" native="true">
+      <layout class="QHBoxLayout" name="headerLayout">
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="appIconLabel">
+         <property name="minimumSize">
+          <size>
+           <width>36</width>
+           <height>36</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>36</width>
+           <height>36</height>
+          </size>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="resources.qrc">:/icons/app_logo.svg</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="appTitleLabel">
+         <property name="text">
+          <string>柔性仿真工作台</string>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">font-size:20px; font-weight:600;</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="headerSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="showPlanPushButton">
+         <property name="text">
+          <string>方案库</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources.qrc">
+           <normaloff>:/icons/gallery.svg</normaloff>:/icons/gallery.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>18</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>查看所有方案</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addSchemeButton">
+         <property name="text">
+          <string>新增方案</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources.qrc">
+           <normaloff>:/icons/add.svg</normaloff>:/icons/add.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>18</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>创建一个新的方案</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addModelButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>添加模型</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources.qrc">
+           <normaloff>:/icons/model_add.svg</normaloff>:/icons/model_add.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>18</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>向当前方案导入模型</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="openWorkspaceButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>打开目录</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources.qrc">
+           <normaloff>:/icons/folder.svg</normaloff>:/icons/folder.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>18</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>打开选中方案或模型的所在目录</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QSplitter" name="mainSplitter">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QWidget" name="widget" native="true">
-       <layout class="QVBoxLayout" name="verticalLayout">
+      <widget class="QFrame" name="navigationFrame">
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <layout class="QVBoxLayout" name="navigationLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QPushButton" name="showPlanPushButton">
-            <property name="text">
-             <string>添加方案</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+         <widget class="QLabel" name="navigationTitle">
+          <property name="text">
+           <string>方案与模型</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font-size:15px;font-weight:600;</string>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="SchemeTreeWidget" name="treeModels">
@@ -57,8 +225,11 @@
             <height>0</height>
            </size>
           </property>
-          <property name="headerHidden">
-           <bool>false</bool>
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="rootIsDecorated">
+           <bool>true</bool>
           </property>
           <column>
            <property name="text">
@@ -67,57 +238,237 @@
           </column>
          </widget>
         </item>
+        <item>
+         <widget class="QLabel" name="navigationHint">
+          <property name="text">
+           <string>可将模型文件夹拖拽到此处进行导入</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color:#6b7280;font-size:12px;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="planPage">
-        <layout class="QGridLayout" name="gridLayout_2"/>
+        <layout class="QVBoxLayout" name="planPageLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
        </widget>
        <widget class="QWidget" name="MainPage">
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="1" column="3">
-          <widget class="QVTKOpenGLNativeWidget" name="vtkWidget" native="true">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>500</height>
-            </size>
+        <layout class="QVBoxLayout" name="mainPageLayout">
+         <property name="spacing">
+          <number>12</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QSplitter" name="contentSplitter">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <widget class="QWidget" name="detailPanel" native="true">
+            <layout class="QVBoxLayout" name="detailPanelLayout">
+             <property name="spacing">
+              <number>8</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="detailTitle">
+               <property name="text">
+                <string>参数设置</string>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">font-size:15px;font-weight:600;</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QScrollArea" name="detailScrollArea">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="widgetResizable">
+                <bool>true</bool>
+               </property>
+               <widget class="QWidget" name="scrollAreaWidgetContents">
+                <property name="geometry">
+                 <rect>
+                  <x>0</x>
+                  <y>0</y>
+                  <width>100</width>
+                  <height>100</height>
+                 </rect>
+                </property>
+                <layout class="QVBoxLayout" name="scrollAreaLayout">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QWidget" name="settingWidget" native="true">
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="detailSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>40</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="vtkPanel" native="true">
+            <layout class="QVBoxLayout" name="vtkPanelLayout">
+             <property name="spacing">
+              <number>8</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="vtkTitle">
+               <property name="text">
+                <string>模型预览</string>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">font-size:15px;font-weight:600;</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QFrame" name="vtkFrame">
+               <property name="frameShape">
+                <enum>QFrame::StyledPanel</enum>
+               </property>
+               <property name="frameShadow">
+                <enum>QFrame::Raised</enum>
+               </property>
+               <layout class="QVBoxLayout" name="vtkFrameLayout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QVTKOpenGLNativeWidget" name="vtkWidget" native="true">
+                  <property name="minimumSize">
+                   <size>
+                    <width>400</width>
+                    <height>420</height>
+                   </size>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="logTitle">
+           <property name="text">
+            <string>运行日志</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">font-size:15px;font-weight:600;</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1" rowspan="3">
-          <widget class="QWidget" name="widget_3" native="true">
-           <layout class="QVBoxLayout" name="verticalLayout_2">
-            <item>
-             <widget class="QPushButton" name="pushButton_7">
-              <property name="text">
-               <string>设置窗口</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_2" native="true">
-              <layout class="QVBoxLayout" name="verticalLayout_3">
-               <item>
-                <layout class="QVBoxLayout" name="vizLayout">
-                 <item>
-                  <widget class="QWidget" name="settingWidget" native="true"/>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="2" column="3">
+         <item>
           <widget class="QPlainTextEdit" name="logTextEdit">
            <property name="readOnly">
             <bool>true</bool>
+           </property>
+           <property name="maximumBlockCount">
+            <number>1000</number>
            </property>
            <property name="placeholderText">
             <string>日志输出...</string>
@@ -136,7 +487,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1224</width>
+     <width>1320</width>
      <height>30</height>
     </rect>
    </property>
@@ -168,6 +519,8 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/SchemeSettingsDialog.cpp
+++ b/SchemeSettingsDialog.cpp
@@ -4,26 +4,86 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QDir>
 
-SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName, QWidget* parent)
+SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
+                                           const QString& workingDirectory,
+                                           bool allowDirectoryChange,
+                                           QWidget* parent)
     : QDialog(parent)
+    , m_directoryEditable(allowDirectoryChange)
 {
-    setWindowTitle("方案设置");
-    resize(420, 220);
+    setWindowTitle(tr("方案设置"));
+    resize(480, 240);
 
-    auto *v = new QVBoxLayout(this);
-    m_title = new QLabel(QString("正在编辑：%1").arg(schemeName), this);
+    auto* v = new QVBoxLayout(this);
+    v->setContentsMargins(16, 16, 16, 16);
+    v->setSpacing(12);
+
+    m_title = new QLabel(tr("正在编辑：%1").arg(schemeName), this);
     m_title->setStyleSheet("font-weight:600;font-size:14px;");
     v->addWidget(m_title);
 
-    auto *row = new QHBoxLayout();
-    row->addWidget(new QLabel("方案名称：", this));
+    auto* nameRow = new QHBoxLayout();
+    nameRow->addWidget(new QLabel(tr("方案名称："), this));
     m_nameEdit = new QLineEdit(schemeName, this);
-    row->addWidget(m_nameEdit);
-    v->addLayout(row);
+    m_nameEdit->setPlaceholderText(tr("请输入方案名称"));
+    nameRow->addWidget(m_nameEdit, 1);
+    v->addLayout(nameRow);
 
-    auto *btns = new QDialogButtonBox(QDialogButtonBox::Ok|QDialogButtonBox::Cancel, this);
+    auto* dirRow = new QHBoxLayout();
+    dirRow->addWidget(new QLabel(tr("工作目录："), this));
+    m_directoryEdit = new QLineEdit(workingDirectory, this);
+    m_directoryEdit->setPlaceholderText(tr("请选择模型计算的工作目录"));
+    m_directoryEdit->setReadOnly(!allowDirectoryChange);
+    dirRow->addWidget(m_directoryEdit, 1);
+    m_browseButton = new QPushButton(tr("浏览..."), this);
+    m_browseButton->setEnabled(allowDirectoryChange);
+    dirRow->addWidget(m_browseButton);
+    v->addLayout(dirRow);
+
+    if (allowDirectoryChange)
+        connect(m_browseButton, &QPushButton::clicked, this, &SchemeSettingsDialog::browseForDirectory);
+
+    auto* btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
     v->addWidget(btns);
+}
+
+QString SchemeSettingsDialog::schemeName() const
+{
+    return m_nameEdit ? m_nameEdit->text().trimmed() : QString();
+}
+
+QString SchemeSettingsDialog::workingDirectory() const
+{
+    return m_directoryEdit ? QDir::cleanPath(m_directoryEdit->text().trimmed()) : QString();
+}
+
+void SchemeSettingsDialog::setSchemeName(const QString& name)
+{
+    if (m_nameEdit)
+        m_nameEdit->setText(name);
+    if (m_title)
+        m_title->setText(tr("正在编辑：%1").arg(name));
+}
+
+void SchemeSettingsDialog::setWorkingDirectory(const QString& directory)
+{
+    if (m_directoryEdit)
+        m_directoryEdit->setText(QDir::toNativeSeparators(directory));
+}
+
+void SchemeSettingsDialog::browseForDirectory()
+{
+    if (!m_directoryEditable)
+        return;
+
+    const QString dir = QFileDialog::getExistingDirectory(this, tr("选择工作目录"),
+                                                          workingDirectory());
+    if (!dir.isEmpty())
+        setWorkingDirectory(dir);
 }

--- a/SchemeSettingsDialog.h
+++ b/SchemeSettingsDialog.h
@@ -3,13 +3,29 @@
 
 class QLineEdit;
 class QLabel;
+class QPushButton;
 
-class SchemeSettingsDialog : public QDialog {
+class SchemeSettingsDialog : public QDialog
+{
     Q_OBJECT
 public:
-    explicit SchemeSettingsDialog(const QString& schemeName, QWidget* parent=nullptr);
+    explicit SchemeSettingsDialog(const QString& schemeName,
+                                  const QString& workingDirectory = QString(),
+                                  bool allowDirectoryChange = true,
+                                  QWidget* parent = nullptr);
+
+    QString schemeName() const;
+    QString workingDirectory() const;
+    void setSchemeName(const QString& name);
+    void setWorkingDirectory(const QString& directory);
+
+private slots:
+    void browseForDirectory();
 
 private:
-    QLabel* m_title;
-    QLineEdit* m_nameEdit;
+    QLabel* m_title = nullptr;
+    QLineEdit* m_nameEdit = nullptr;
+    QLineEdit* m_directoryEdit = nullptr;
+    QPushButton* m_browseButton = nullptr;
+    bool m_directoryEditable = true;
 };

--- a/icons/add.svg
+++ b/icons/add.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#22c55e"/>
+  <path d="M11 7h2v4h4v2h-4v4h-2v-4H7v-2h4z" fill="#f8fafc"/>
+  <circle cx="12" cy="12" r="10" fill="none" stroke="#16a34a" stroke-width="1.5" opacity="0.6"/>
+</svg>

--- a/icons/app_logo.svg
+++ b/icons/app_logo.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="28" fill="#2563eb"/>
+  <path d="M22 18h20v6H28v8h12v6H28v14h-6V18z" fill="#f8fafc"/>
+  <path d="M32 6a26 26 0 1 1-26 26A26 26 0 0 1 32 6zm0 4a22 22 0 1 0 22 22A22 22 0 0 0 32 10z" fill="#1d4ed8" opacity="0.35"/>
+</svg>

--- a/icons/folder.svg
+++ b/icons/folder.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v1H3z" fill="#fbbf24"/>
+  <path d="M3 9h18v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" fill="#f59e0b"/>
+  <path d="M5 10h14v6a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1z" fill="#fde68a" opacity="0.65"/>
+  <path d="M9 4h2l2 2H9z" fill="#fcd34d"/>
+  <rect x="3" y="6" width="18" height="12" rx="2" ry="2" fill="none" stroke="#d97706" stroke-width="1.2" opacity="0.6"/>
+</svg>

--- a/icons/gallery.svg
+++ b/icons/gallery.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="4" width="18" height="16" rx="3" fill="#a855f7"/>
+  <rect x="6" y="7" width="5" height="4" rx="1" fill="#f8fafc" opacity="0.85"/>
+  <rect x="13" y="7" width="5" height="4" rx="1" fill="#f8fafc" opacity="0.85"/>
+  <rect x="6" y="13" width="5" height="4" rx="1" fill="#f8fafc" opacity="0.85"/>
+  <rect x="13" y="13" width="5" height="4" rx="1" fill="#f8fafc" opacity="0.85"/>
+  <rect x="3" y="4" width="18" height="16" rx="3" fill="none" stroke="#7c3aed" stroke-width="1.4" opacity="0.6"/>
+</svg>

--- a/icons/model.svg
+++ b/icons/model.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 7l7-4 7 4v10l-7 4-7-4z" fill="#60a5fa"/>
+  <path d="M12 3v18l7-4V7z" fill="#3b82f6"/>
+  <path d="M12 3L5 7v10l7 4z" fill="#93c5fd" opacity="0.9"/>
+  <path d="M5 7l7 4 7-4" fill="none" stroke="#1d4ed8" stroke-width="1.2" opacity="0.6"/>
+  <path d="M12 11v10" fill="none" stroke="#1d4ed8" stroke-width="1.2" opacity="0.6"/>
+</svg>

--- a/icons/model_add.svg
+++ b/icons/model_add.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="5" width="14" height="12" rx="2" fill="#38bdf8"/>
+  <path d="M6 9h10v2H6z" fill="#0f172a" opacity="0.25"/>
+  <path d="M6 12h6v2H6z" fill="#0f172a" opacity="0.25"/>
+  <circle cx="17" cy="17" r="5" fill="#1d4ed8"/>
+  <path d="M16 14.5h2v2.5h2v2h-2v2.5h-2v-2.5h-2v-2h2z" fill="#f8fafc"/>
+  <rect x="4" y="5" width="14" height="12" rx="2" fill="none" stroke="#0ea5e9" stroke-width="1.2" opacity="0.7"/>
+</svg>

--- a/icons/plan.svg
+++ b/icons/plan.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="3" width="16" height="18" rx="2" fill="#38bdf8"/>
+  <path d="M8 7h8v2H8zM8 11h10v2H8zM8 15h6v2H8z" fill="#0f172a" opacity="0.3"/>
+  <path d="M6 5h2v2H6zM6 9h2v2H6zM6 13h2v2H6z" fill="#f8fafc" opacity="0.8"/>
+  <rect x="4" y="3" width="16" height="18" rx="2" fill="none" stroke="#0ea5e9" stroke-width="1.2" opacity="0.7"/>
+</svg>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,46 +1,149 @@
-﻿#include "MainWindow.h"
+#include "MainWindow.h"
 #include "ui_MainWindow.h"
 
 #include "JsonPageBuilder.h"
 #include "SchemeGalleryWidget.h"
+#include "SchemeSettingsDialog.h"
 #include "SchemeTreeWidget.h"
 
-#include <QTreeWidgetItem>
-#include <QHeaderView>
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QListWidget>
-#include <QPushButton>
-#include <QPlainTextEdit>
-#include <QLabel>
-#include <QMenu>
 #include <QAction>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QDesktopServices>
-#include <QUrl>
-#include <QFileInfo>
-#include <QDir>
-#include <QProcess>
-#include <QDebug>
-#include <QShortcut>
-#include <QUuid>
-#include <QPainter>
 #include <QApplication>
-#include <QSignalBlocker>
-#include <QSet>
 #include <QCoreApplication>
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QFont>
+#include <QHeaderView>
+#include <QIcon>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QListWidget>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPainter>
+#include <QPlainTextEdit>
+#include <QProcess>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QScrollBar>
+#include <QScrollArea>
+#include <QSet>
+#include <QShortcut>
+#include <QSplitter>
+#include <QStandardPaths>
+#include <QStringList>
+#include <QTreeWidgetItem>
+#include <QUuid>
+#include <QVBoxLayout>
+
+#include <QVTKOpenGLNativeWidget.h>
+#include <vtkActor.h>
+#include <vtkCamera.h>
+#include <vtkGenericOpenGLRenderWindow.h>
+#include <vtkNamedColors.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkSTLReader.h>
 
 namespace
 {
-    QString canonicalPathForDir(const QDir& dir)
+QString canonicalPathForDir(const QDir& dir)
+{
+    QString canonical = dir.canonicalPath();
+    if (canonical.isEmpty())
+        canonical = dir.absolutePath();
+    return QDir::cleanPath(canonical);
+}
+
+bool ensureDirectoryExists(const QString& path)
+{
+    QDir dir(path);
+    return dir.exists() || dir.mkpath(QStringLiteral("."));
+}
+
+bool copyDirectoryRecursively(const QString& sourcePath, const QString& targetPath)
+{
+    QDir source(sourcePath);
+    if (!source.exists())
+        return false;
+
+    QDir target(targetPath);
+    if (!target.exists() && !target.mkpath(QStringLiteral(".")))
+        return false;
+
+    const QFileInfoList entries = source.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
+    for (const QFileInfo& entry : entries)
     {
-        QString canonical = dir.canonicalPath();
-        if (canonical.isEmpty())
-            canonical = dir.absolutePath();
-        return QDir::cleanPath(canonical);
+        const QString targetFilePath = target.filePath(entry.fileName());
+        if (entry.isDir())
+        {
+            if (!copyDirectoryRecursively(entry.absoluteFilePath(), targetFilePath))
+                return false;
+        }
+        else
+        {
+            QFile::remove(targetFilePath);
+            if (!QFile::copy(entry.absoluteFilePath(), targetFilePath))
+                return false;
+        }
     }
+    return true;
+}
+
+bool moveDirectoryTo(const QString& sourcePath, const QString& targetPath)
+{
+    if (sourcePath == targetPath)
+        return true;
+
+    QDir targetParent = QFileInfo(targetPath).dir();
+    if (!targetParent.exists() && !targetParent.mkpath(QStringLiteral(".")))
+        return false;
+
+    QDir dir;
+    if (dir.rename(sourcePath, targetPath))
+        return true;
+
+    if (!copyDirectoryRecursively(sourcePath, targetPath))
+        return false;
+
+    QDir source(sourcePath);
+    return source.removeRecursively();
+}
+
+QString uniqueChildPath(const QDir& parent, const QString& baseName)
+{
+    QString sanitized = baseName.trimmed();
+    if (sanitized.isEmpty())
+        sanitized = QStringLiteral("Model");
+
+    QString candidateName = sanitized;
+    QString candidatePath = parent.filePath(candidateName);
+    int index = 1;
+    while (QDir(candidatePath).exists())
+    {
+        candidateName = QStringLiteral("%1_%2").arg(sanitized).arg(index++);
+        candidatePath = parent.filePath(candidateName);
+    }
+    return candidatePath;
+}
+
+QString latestStlFile(const QString& directory)
+{
+    QDir dir(directory);
+    const QFileInfoList files = dir.entryInfoList(QStringList() << "*.stl" << "*.STL",
+                                                  QDir::Files, QDir::Time | QDir::IgnoreCase);
+    if (!files.isEmpty())
+        return files.first().absoluteFilePath();
+    return QString();
+}
 }
 
 MainWindow::MainWindow(QWidget *parent)
@@ -49,6 +152,14 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
 
+    const QString dataRoot = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir dataDir(dataRoot);
+    if (!dataDir.exists())
+        dataDir.mkpath(QStringLiteral("."));
+    m_workspaceRoot = dataDir.filePath(QStringLiteral("workspaces"));
+    ensureDirectoryExists(m_workspaceRoot);
+    m_storageFilePath = dataDir.filePath(QStringLiteral("schemes.json"));
+
     setupUiHelpers();
     setupConnections();
     loadInitialSchemes();
@@ -56,25 +167,48 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
+    saveSchemesToStorage();
     delete ui;
 }
 
 void MainWindow::setupUiHelpers()
 {
-    // Gallery view on plan page
     m_galleryWidget = new SchemeGalleryWidget(this);
-    ui->gridLayout_2->addWidget(m_galleryWidget, 0, 0);
+    ui->planPageLayout->addWidget(m_galleryWidget);
 
-    // Detail panel layout
     auto* detailLayout = new QVBoxLayout(ui->settingWidget);
     detailLayout->setContentsMargins(12, 12, 12, 12);
     detailLayout->setSpacing(12);
 
-    // Tree widget configuration
     ui->treeModels->header()->setStretchLastSection(true);
     ui->treeModels->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeModels->setEditTriggers(QAbstractItemView::EditKeyPressed |
                                     QAbstractItemView::SelectedClicked);
+
+    ui->mainSplitter->setStretchFactor(0, 0);
+    ui->mainSplitter->setStretchFactor(1, 1);
+    ui->contentSplitter->setStretchFactor(0, 0);
+    ui->contentSplitter->setStretchFactor(1, 1);
+
+    const QString buttonStyle =
+        "QPushButton{padding:6px 12px;border:1px solid #d0d5dd;"
+        "border-radius:6px;background:#f5f7fb;}"
+        "QPushButton:hover{background:#e8efff;}";
+    ui->showPlanPushButton->setStyleSheet(buttonStyle);
+    ui->addSchemeButton->setStyleSheet(buttonStyle);
+    ui->addModelButton->setStyleSheet(buttonStyle);
+    ui->openWorkspaceButton->setStyleSheet(buttonStyle);
+
+    ui->logTextEdit->setStyleSheet(
+        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border-radius:6px;padding:6px;}"
+    );
+
+    auto colors = vtkSmartPointer<vtkNamedColors>::New();
+    m_renderWindow = vtkSmartPointer<vtkGenericOpenGLRenderWindow>::New();
+    m_renderer = vtkSmartPointer<vtkRenderer>::New();
+    m_renderer->SetBackground(colors->GetColor3d("AliceBlue").GetData());
+    m_renderWindow->AddRenderer(m_renderer);
+    ui->vtkWidget->setRenderWindow(m_renderWindow);
 }
 
 void MainWindow::setupConnections()
@@ -94,6 +228,29 @@ void MainWindow::setupConnections()
                 this, &MainWindow::onExternalDrop);
     }
 
+    connect(ui->showPlanPushButton, &QPushButton::clicked,
+            this, &MainWindow::on_showPlanPushButton_clicked);
+    connect(ui->addSchemeButton, &QPushButton::clicked,
+            this, &MainWindow::promptAddScheme);
+    connect(ui->addModelButton, &QPushButton::clicked, this, [this]() {
+        if (!m_activeSchemeId.isEmpty())
+            promptAddModel(m_activeSchemeId);
+    });
+    connect(ui->openWorkspaceButton, &QPushButton::clicked, this, [this]() {
+        if (!m_activeModelId.isEmpty())
+        {
+            SchemeRecord* owner = nullptr;
+            if (ModelRecord* model = modelById(m_activeModelId, &owner))
+                QDesktopServices::openUrl(QUrl::fromLocalFile(model->directory));
+            return;
+        }
+        if (!m_activeSchemeId.isEmpty())
+        {
+            if (SchemeRecord* scheme = schemeById(m_activeSchemeId))
+                QDesktopServices::openUrl(QUrl::fromLocalFile(scheme->workingDirectory));
+        }
+    });
+
     connect(m_galleryWidget, &SchemeGalleryWidget::addSchemeRequested,
             this, &MainWindow::onGalleryAddRequested);
     connect(m_galleryWidget, &SchemeGalleryWidget::schemeOpenRequested,
@@ -108,10 +265,19 @@ void MainWindow::setupConnections()
 
 void MainWindow::loadInitialSchemes()
 {
+    if (loadSchemesFromStorage())
+    {
+        refreshNavigation();
+        ui->stackedWidget->setCurrentWidget(ui->planPage);
+        updateToolbarState();
+        return;
+    }
+
+    QVector<SchemeRecord> imported;
     const QStringList candidateRoots = {
-        QDir::current().absoluteFilePath("sample_data"),
-        QCoreApplication::applicationDirPath() + "/sample_data",
-        QCoreApplication::applicationDirPath() + "/../sample_data"
+        QDir::current().absoluteFilePath(QStringLiteral("sample_data")),
+        QCoreApplication::applicationDirPath() + QStringLiteral("/sample_data"),
+        QCoreApplication::applicationDirPath() + QStringLiteral("/../sample_data")
     };
 
     for (const QString& rootPath : candidateRoots)
@@ -123,14 +289,28 @@ void MainWindow::loadInitialSchemes()
         const QStringList schemeDirs = rootDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
         for (const QString& name : schemeDirs)
         {
-            importSchemeFromDirectory(rootDir.absoluteFilePath(name), false);
+            const QString sourcePath = rootDir.absoluteFilePath(name);
+            const QString workspacePath = makeUniqueWorkspaceSubdir(name);
+            if (!copyDirectoryRecursively(sourcePath, workspacePath))
+                continue;
+
+            SchemeRecord scheme;
+            scheme.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+            scheme.name = name;
+            scheme.workingDirectory = canonicalPathForDir(QDir(workspacePath));
+            scheme.models = scanSchemeFolder(workspacePath);
+            imported.push_back(scheme);
         }
-        if (!m_schemes.isEmpty())
+
+        if (!imported.isEmpty())
             break;
     }
 
+    m_schemes = imported;
+    persistSchemes();
     refreshNavigation();
     ui->stackedWidget->setCurrentWidget(ui->planPage);
+    updateToolbarState();
 }
 
 void MainWindow::on_showPlanPushButton_clicked()
@@ -146,6 +326,8 @@ void MainWindow::handleTreeSelectionChanged(QTreeWidgetItem* current, QTreeWidge
         m_activeSchemeId.clear();
         m_activeModelId.clear();
         clearDetailWidget();
+        clearVtkScene();
+        updateToolbarState();
         return;
     }
 
@@ -158,6 +340,7 @@ void MainWindow::handleTreeSelectionChanged(QTreeWidgetItem* current, QTreeWidge
         m_activeModelId.clear();
         ui->stackedWidget->setCurrentWidget(ui->MainPage);
         showSchemeSettings(schemeId);
+        clearVtkScene();
     }
     else if (type == ModelItem)
     {
@@ -168,6 +351,7 @@ void MainWindow::handleTreeSelectionChanged(QTreeWidgetItem* current, QTreeWidge
         ui->stackedWidget->setCurrentWidget(ui->MainPage);
         showModelSettings(modelId);
     }
+    updateToolbarState();
 }
 
 void MainWindow::onTreeItemChanged(QTreeWidgetItem* item, int column)
@@ -185,6 +369,7 @@ void MainWindow::onTreeItemChanged(QTreeWidgetItem* item, int column)
         if (SchemeRecord* scheme = schemeById(id))
         {
             scheme->name = item->text(0);
+            persistSchemes();
             updateGallery();
             refreshCurrentDetail();
         }
@@ -195,6 +380,7 @@ void MainWindow::onTreeItemChanged(QTreeWidgetItem* item, int column)
         if (ModelRecord* model = modelById(id, &owner))
         {
             model->name = item->text(0);
+            persistSchemes();
             refreshCurrentDetail();
         }
     }
@@ -215,12 +401,15 @@ void MainWindow::onTreeContextMenuRequested(const QPoint& pos)
         if (type == SchemeItem)
         {
             const QString schemeId = item->data(0, IdRole).toString();
+            menu.addAction(tr("方案设置"), this, [this, schemeId]() {
+                openSchemeSettings(schemeId);
+            });
             menu.addAction(tr("添加模型"), this, [this, schemeId]() {
                 promptAddModel(schemeId);
             });
             menu.addAction(tr("打开方案目录"), this, [this, schemeId]() {
                 if (SchemeRecord* scheme = schemeById(schemeId))
-                    QDesktopServices::openUrl(QUrl::fromLocalFile(scheme->directory));
+                    QDesktopServices::openUrl(QUrl::fromLocalFile(scheme->workingDirectory));
             });
             menu.addSeparator();
             menu.addAction(tr("删除方案"), this, [this, schemeId]() {
@@ -230,7 +419,6 @@ void MainWindow::onTreeContextMenuRequested(const QPoint& pos)
         else if (type == ModelItem)
         {
             const QString modelId = item->data(0, IdRole).toString();
-            SchemeRecord* owner = nullptr;
             menu.addAction(tr("打开模型目录"), this, [this, modelId]() {
                 SchemeRecord* owner = nullptr;
                 if (ModelRecord* model = modelById(modelId, &owner))
@@ -351,6 +539,7 @@ void MainWindow::refreshNavigation(const QString& schemeToSelect,
     selectTreeItem(schemeId, modelId);
     if (!ui->treeModels->currentItem())
         clearDetailWidget();
+    updateToolbarState();
 }
 
 void MainWindow::rebuildTree()
@@ -362,10 +551,14 @@ void MainWindow::rebuildTree()
     m_schemeItems.clear();
     m_modelItems.clear();
 
+    const QIcon schemeIcon(QStringLiteral(":/icons/plan.svg"));
+    const QIcon modelIcon(QStringLiteral(":/icons/model.svg"));
+
     for (const SchemeRecord& scheme : m_schemes)
     {
         auto* schemeItem = new QTreeWidgetItem(ui->treeModels);
         schemeItem->setText(0, scheme.name);
+        schemeItem->setIcon(0, schemeIcon);
         schemeItem->setData(0, TypeRole, SchemeItem);
         schemeItem->setData(0, IdRole, scheme.id);
         schemeItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled |
@@ -377,6 +570,7 @@ void MainWindow::rebuildTree()
         {
             auto* modelItem = new QTreeWidgetItem(schemeItem);
             modelItem->setText(0, model.name);
+            modelItem->setIcon(0, modelIcon);
             modelItem->setData(0, TypeRole, ModelItem);
             modelItem->setData(0, IdRole, model.id);
             modelItem->setData(0, SchemeRole, scheme.id);
@@ -407,8 +601,7 @@ void MainWindow::selectTreeItem(const QString& schemeId, const QString& modelId)
 {
     if (!modelId.isEmpty())
     {
-        // 如果 m_modelItems 是 QHash
-        QHash<QString, QTreeWidgetItem*>::iterator it = m_modelItems.find(modelId);
+        auto it = m_modelItems.find(modelId);
         if (it != m_modelItems.end())
         {
             ui->treeModels->setCurrentItem(it.value());
@@ -418,8 +611,7 @@ void MainWindow::selectTreeItem(const QString& schemeId, const QString& modelId)
 
     if (!schemeId.isEmpty())
     {
-        // 如果 m_schemeItems 是 QHash
-        QHash<QString, QTreeWidgetItem*>::iterator it = m_schemeItems.find(schemeId);
+        auto it = m_schemeItems.find(schemeId);
         if (it != m_schemeItems.end())
         {
             ui->treeModels->setCurrentItem(it.value());
@@ -430,7 +622,6 @@ void MainWindow::selectTreeItem(const QString& schemeId, const QString& modelId)
     if (ui->treeModels->topLevelItemCount() > 0)
         ui->treeModels->setCurrentItem(ui->treeModels->topLevelItem(0));
 }
-
 
 void MainWindow::clearDetailWidget()
 {
@@ -465,12 +656,25 @@ void MainWindow::showModelSettings(const QString& modelId)
     if (!model)
     {
         clearDetailWidget();
+        clearVtkScene();
         return;
     }
 
     clearDetailWidget();
     m_currentDetailWidget = buildModelSettingsWidget(*model);
     ui->settingWidget->layout()->addWidget(m_currentDetailWidget);
+
+    const QString stl = latestStlFile(model->directory);
+    if (!stl.isEmpty())
+    {
+        appendLogMessage(tr("加载最近的 STL：%1")
+                             .arg(QDir::toNativeSeparators(stl)));
+        displayStlFile(stl);
+    }
+    else
+    {
+        clearVtkScene();
+    }
 }
 
 QWidget* MainWindow::buildSchemeSettingsWidget(const SchemeRecord& scheme)
@@ -484,7 +688,9 @@ QWidget* MainWindow::buildSchemeSettingsWidget(const SchemeRecord& scheme)
     title->setStyleSheet("font-size:18px;font-weight:600;");
     layout->addWidget(title);
 
-    auto* pathLabel = new QLabel(tr("目录：%1").arg(QDir::toNativeSeparators(scheme.directory)), container);
+    auto* pathLabel = new QLabel(tr("工作目录：%1")
+                                     .arg(QDir::toNativeSeparators(scheme.workingDirectory)),
+                                 container);
     pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(pathLabel);
 
@@ -512,7 +718,7 @@ QWidget* MainWindow::buildSchemeSettingsWidget(const SchemeRecord& scheme)
     buttonRow->addWidget(addBtn);
 
     auto* openBtn = new QPushButton(tr("打开方案目录"), container);
-    connect(openBtn, &QPushButton::clicked, this, [path = scheme.directory]() {
+    connect(openBtn, &QPushButton::clicked, this, [path = scheme.workingDirectory]() {
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });
     buttonRow->addWidget(openBtn);
@@ -533,16 +739,33 @@ QWidget* MainWindow::buildModelSettingsWidget(const ModelRecord& model)
     title->setStyleSheet("font-size:18px;font-weight:600;");
     layout->addWidget(title);
 
-    auto* pathLabel = new QLabel(tr("目录：%1").arg(QDir::toNativeSeparators(model.directory)), container);
+    auto* pathLabel = new QLabel(tr("目录：%1")
+                                     .arg(QDir::toNativeSeparators(model.directory)),
+                                 container);
     pathLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(pathLabel);
 
-    auto* jsonLabel = new QLabel(tr("配置文件：%1").arg(QDir::toNativeSeparators(model.jsonPath)), container);
+    auto* jsonLabel = new QLabel(tr("配置文件：%1")
+                                     .arg(QDir::toNativeSeparators(model.jsonPath)),
+                                 container);
     jsonLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     layout->addWidget(jsonLabel);
 
     auto* builder = new JsonPageBuilder(model.jsonPath, container);
     layout->addWidget(builder, 1);
+
+    connect(builder, &JsonPageBuilder::logMessage,
+            this, &MainWindow::appendLogMessage);
+    connect(builder, &JsonPageBuilder::calculationFinished,
+            this, [this](const QString& stlPath) {
+        if (stlPath.isEmpty())
+        {
+            appendLogMessage(tr("未检测到新的 STL 输出文件"));
+            return;
+        }
+        appendLogMessage(tr("加载 STL：%1").arg(QDir::toNativeSeparators(stlPath)));
+        displayStlFile(stlPath);
+    });
 
     auto* openBtn = new QPushButton(tr("打开模型目录"), container);
     connect(openBtn, &QPushButton::clicked, this, [path = model.directory]() {
@@ -583,11 +806,11 @@ const MainWindow::SchemeRecord* MainWindow::schemeById(const QString& id) const
     return nullptr;
 }
 
-MainWindow::SchemeRecord* MainWindow::schemeByDirectory(const QString& canonicalPath)
+MainWindow::SchemeRecord* MainWindow::schemeByWorkingDirectory(const QString& canonicalPath)
 {
     for (SchemeRecord& scheme : m_schemes)
     {
-        if (canonicalPathForDir(QDir(scheme.directory)) == canonicalPath)
+        if (canonicalPathForDir(QDir(scheme.workingDirectory)) == canonicalPath)
             return &scheme;
     }
     return nullptr;
@@ -631,6 +854,27 @@ const MainWindow::ModelRecord* MainWindow::modelById(const QString& id, const Sc
     return nullptr;
 }
 
+QString MainWindow::createScheme(const QString& name, const QString& workingDir)
+{
+    const QString trimmedName = name.trimmed();
+    if (trimmedName.isEmpty())
+        return QString();
+
+    const QString canonical = canonicalPathForDir(QDir(workingDir));
+    if (canonical.isEmpty())
+        return QString();
+
+    if (SchemeRecord* existing = schemeByWorkingDirectory(canonical))
+        return existing->id;
+
+    SchemeRecord scheme;
+    scheme.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    scheme.name = trimmedName;
+    scheme.workingDirectory = canonical;
+    m_schemes.push_back(scheme);
+    return scheme.id;
+}
+
 QString MainWindow::importSchemeFromDirectory(const QString& dirPath, bool showError)
 {
     QDir dir(dirPath);
@@ -643,73 +887,55 @@ QString MainWindow::importSchemeFromDirectory(const QString& dirPath, bool showE
     }
 
     const QString canonical = canonicalPathForDir(dir);
-    if (schemeByDirectory(canonical))
-    {
-        if (showError)
-            QMessageBox::information(this, tr("提示"),
-                                     tr("方案已存在：%1").arg(QDir::toNativeSeparators(dirPath)));
-        return QString();
-    }
 
-    QVector<ModelRecord> models = scanSchemeFolder(canonical);
-    if (models.isEmpty())
+    if (SchemeRecord* existing = schemeByWorkingDirectory(canonical))
     {
-        QString jsonPath, batPath;
-        if (isModelFolder(dir, &jsonPath, &batPath))
-        {
-            ModelRecord single;
-            single.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
-            single.name = dir.dirName();
-            single.directory = canonical;
-            single.jsonPath = jsonPath;
-            single.batPath = batPath;
-            models.push_back(single);
-        }
-    }
-    if (models.isEmpty())
-    {
-        if (showError)
-            QMessageBox::warning(this, tr("导入失败"),
-                                 tr("未在目录中找到有效的模型：%1").arg(QDir::toNativeSeparators(dirPath)));
-        return QString();
+        existing->name = dir.dirName();
+        existing->models = scanSchemeFolder(canonical);
+        persistSchemes();
+        refreshNavigation(existing->id);
+        return existing->id;
     }
 
     SchemeRecord scheme;
     scheme.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
     scheme.name = dir.dirName();
-    scheme.directory = canonical;
-
-    for (ModelRecord& model : models)
-    {
-        if (model.id.isEmpty())
-            model.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
-        if (model.directory.isEmpty())
-            model.directory = QDir(canonical).filePath(model.name);
-        scheme.models.push_back(model);
-    }
+    scheme.workingDirectory = canonical;
+    scheme.models = scanSchemeFolder(canonical);
 
     m_schemes.push_back(scheme);
+    persistSchemes();
     refreshNavigation(scheme.id);
     return scheme.id;
 }
 
 QVector<QString> MainWindow::importModelsIntoScheme(const QString& schemeId,
-                                                   const QStringList& paths,
-                                                   bool showError)
+                                                    const QStringList& paths,
+                                                    bool showError)
 {
     QVector<QString> addedIds;
     SchemeRecord* scheme = schemeById(schemeId);
     if (!scheme)
         return addedIds;
 
+    if (!ensureDirectoryExists(scheme->workingDirectory))
+    {
+        if (showError)
+            QMessageBox::warning(this, tr("导入失败"),
+                                 tr("无法创建方案工作目录：%1")
+                                     .arg(QDir::toNativeSeparators(scheme->workingDirectory)));
+        return addedIds;
+    }
+
+    QDir workingDir(scheme->workingDirectory);
     QSet<QString> existingPaths;
     for (const ModelRecord& model : scheme->models)
         existingPaths.insert(canonicalPathForDir(QDir(model.directory)));
 
     for (const QString& path : paths)
     {
-        QDir dir(path);
-        if (!dir.exists())
+        QDir src(path);
+        if (!src.exists())
         {
             if (showError)
                 QMessageBox::warning(this, tr("导入失败"),
@@ -717,52 +943,85 @@ QVector<QString> MainWindow::importModelsIntoScheme(const QString& schemeId,
             continue;
         }
 
-        const QString canonical = canonicalPathForDir(dir);
-
         QString jsonPath, batPath;
-        if (isModelFolder(dir, &jsonPath, &batPath))
+        if (isModelFolder(src, &jsonPath, &batPath))
         {
-            if (existingPaths.contains(canonical))
+            QString destPath = uniqueChildPath(workingDir, src.dirName());
+            if (!moveDirectoryTo(src.absolutePath(), destPath))
+            {
+                if (showError)
+                    QMessageBox::warning(this, tr("导入失败"),
+                                         tr("无法移动模型文件夹：%1")
+                                             .arg(QDir::toNativeSeparators(path)));
                 continue;
+            }
 
+            QDir destDir(destPath);
             ModelRecord model;
             model.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
-            model.name = dir.dirName();
-            model.directory = canonical;
-            model.jsonPath = jsonPath;
-            model.batPath = batPath;
+            model.name = destDir.dirName();
+            model.directory = canonicalPathForDir(destDir);
+            const QString jsonName = QFileInfo(jsonPath).fileName();
+            model.jsonPath = destDir.filePath(jsonName);
+            const QString batName = QFileInfo(batPath).fileName();
+            model.batPath = batName.isEmpty() ? QString() : destDir.filePath(batName);
+            if (existingPaths.contains(model.directory))
+                continue;
+
             scheme->models.push_back(model);
-            existingPaths.insert(canonical);
             addedIds.push_back(model.id);
+            existingPaths.insert(model.directory);
             continue;
         }
 
-        QVector<ModelRecord> nested = scanSchemeFolder(canonical);
+        QVector<ModelRecord> nested = scanSchemeFolder(canonicalPathForDir(src));
         if (nested.isEmpty())
         {
             if (showError)
                 QMessageBox::warning(this, tr("导入失败"),
                                      tr("%1 不是有效的模型文件夹。")
-                                     .arg(QDir::toNativeSeparators(path)));
+                                         .arg(QDir::toNativeSeparators(path)));
             continue;
         }
 
-        for (ModelRecord& model : nested)
+        for (ModelRecord model : nested)
         {
-            const QString modelCanonical = canonicalPathForDir(QDir(model.directory));
-            if (existingPaths.contains(modelCanonical))
+            QDir destDir(uniqueChildPath(workingDir, QFileInfo(model.directory).fileName()));
+            if (!moveDirectoryTo(model.directory, destDir.absolutePath()))
+            {
+                if (showError)
+                    QMessageBox::warning(this, tr("导入失败"),
+                                         tr("无法移动模型文件夹：%1")
+                                             .arg(QDir::toNativeSeparators(model.directory)));
                 continue;
+            }
+
+            model.directory = canonicalPathForDir(destDir);
+            const QString jsonName = QFileInfo(model.jsonPath).fileName();
+            model.jsonPath = destDir.filePath(jsonName);
+            const QString batName = QFileInfo(model.batPath).fileName();
+            model.batPath = batName.isEmpty() ? QString() : destDir.filePath(batName);
             model.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+
+            if (existingPaths.contains(model.directory))
+                continue;
+
             scheme->models.push_back(model);
-            existingPaths.insert(modelCanonical);
             addedIds.push_back(model.id);
+            existingPaths.insert(model.directory);
         }
     }
 
     if (!addedIds.isEmpty())
+    {
+        persistSchemes();
         refreshNavigation(schemeId, addedIds.first());
+        appendLogMessage(tr("成功导入 %1 个模型").arg(addedIds.size()));
+    }
     else
+    {
         refreshNavigation(schemeId, m_activeModelId);
+    }
 
     return addedIds;
 }
@@ -774,12 +1033,12 @@ bool MainWindow::isModelFolder(const QDir& dir, QString* jsonPath, QString* batP
                                              QDir::Files | QDir::NoDotAndDotDot);
     const QStringList bats = copy.entryList(QStringList() << "*.bat",
                                             QDir::Files | QDir::NoDotAndDotDot);
-    if (jsons.isEmpty() || bats.isEmpty())
+    if (jsons.isEmpty())
         return false;
 
     if (jsonPath)
         *jsonPath = copy.absoluteFilePath(jsons.first());
-    if (batPath)
+    if (batPath && !bats.isEmpty())
         *batPath = copy.absoluteFilePath(bats.first());
     return true;
 }
@@ -797,6 +1056,7 @@ QVector<MainWindow::ModelRecord> MainWindow::scanSchemeFolder(const QString& sch
             continue;
 
         ModelRecord model;
+        model.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
         model.name = name;
         model.directory = canonicalPathForDir(child);
         model.jsonPath = jsonPath;
@@ -824,14 +1084,38 @@ QPixmap MainWindow::makeSchemePlaceholder(const QString& name) const
 
 void MainWindow::promptAddScheme()
 {
-    const QString dir = QFileDialog::getExistingDirectory(this, tr("选择方案目录"));
-    if (dir.isEmpty())
+    const QString defaultName = tr("新方案%1").arg(m_schemes.size() + 1);
+    const QString defaultDir = makeUniqueWorkspaceSubdir(defaultName);
+
+    SchemeSettingsDialog dlg(defaultName, defaultDir, true, this);
+    if (dlg.exec() != QDialog::Accepted)
         return;
-    const QString id = importSchemeFromDirectory(dir);
+
+    const QString name = dlg.schemeName();
+    const QString directory = dlg.workingDirectory();
+    if (name.isEmpty() || directory.isEmpty())
+    {
+        QMessageBox::warning(this, tr("创建方案"), tr("方案名称和工作目录不能为空"));
+        return;
+    }
+
+    if (!ensureDirectoryExists(directory))
+    {
+        QMessageBox::warning(this, tr("创建方案"),
+                             tr("无法创建工作目录：%1")
+                                 .arg(QDir::toNativeSeparators(directory)));
+        return;
+    }
+
+    const QString id = importSchemeFromDirectory(directory, false);
     if (!id.isEmpty())
     {
+        if (SchemeRecord* scheme = schemeById(id))
+            scheme->name = name;
+        persistSchemes();
+        refreshNavigation(id);
         ui->stackedWidget->setCurrentWidget(ui->MainPage);
-        selectTreeItem(id, QString());
+        appendLogMessage(tr("已创建方案 %1").arg(name));
     }
 }
 
@@ -852,6 +1136,21 @@ void MainWindow::promptAddModel(const QString& schemeId)
     }
 }
 
+void MainWindow::openSchemeSettings(const QString& schemeId)
+{
+    SchemeRecord* scheme = schemeById(schemeId);
+    if (!scheme)
+        return;
+
+    SchemeSettingsDialog dlg(scheme->name, scheme->workingDirectory, false, this);
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    scheme->name = dlg.schemeName();
+    persistSchemes();
+    refreshNavigation(schemeId, m_activeModelId);
+}
+
 void MainWindow::removeSchemeById(const QString& id)
 {
     for (int i = 0; i < m_schemes.size(); ++i)
@@ -864,7 +1163,9 @@ void MainWindow::removeSchemeById(const QString& id)
                 m_activeSchemeId.clear();
                 m_activeModelId.clear();
             }
+            persistSchemes();
             refreshNavigation();
+            appendLogMessage(tr("已删除方案"));
             return;
         }
     }
@@ -880,23 +1181,11 @@ void MainWindow::removeModelById(const QString& id)
             if (scheme.models[j].id == id)
             {
                 scheme.models.removeAt(j);
-                if (scheme.models.isEmpty())
-                {
-                    const QString schemeId = scheme.id;
-                    m_schemes.removeAt(i);
-                    if (m_activeSchemeId == schemeId)
-                    {
-                        m_activeSchemeId.clear();
-                        m_activeModelId.clear();
-                    }
-                    refreshNavigation();
-                }
-                else
-                {
-                    if (m_activeModelId == id)
-                        m_activeModelId.clear();
-                    refreshNavigation(scheme.id);
-                }
+                if (m_activeModelId == id)
+                    m_activeModelId.clear();
+                persistSchemes();
+                refreshNavigation(scheme.id);
+                appendLogMessage(tr("已删除模型"));
                 return;
             }
         }
@@ -944,10 +1233,213 @@ void MainWindow::syncDataFromTree()
             scheme.models.push_back(model);
         }
 
-        if (!scheme.models.isEmpty())
-            updated.push_back(scheme);
+        updated.push_back(scheme);
     }
 
     m_schemes = updated;
+    persistSchemes();
     refreshNavigation(m_activeSchemeId, m_activeModelId);
+}
+
+void MainWindow::updateToolbarState()
+{
+    const bool hasScheme = !m_activeSchemeId.isEmpty();
+    const bool hasModel = !m_activeModelId.isEmpty();
+    const bool anyScheme = !m_schemes.isEmpty();
+
+    ui->addModelButton->setEnabled(hasScheme);
+    ui->openWorkspaceButton->setEnabled(hasScheme || hasModel);
+    ui->showPlanPushButton->setEnabled(anyScheme);
+}
+
+void MainWindow::appendLogMessage(const QString& message)
+{
+    if (!ui->logTextEdit)
+        return;
+
+    const QString timeStamp = QDateTime::currentDateTime().toString("hh:mm:ss");
+    ui->logTextEdit->appendPlainText(QStringLiteral("[%1] %2").arg(timeStamp, message));
+    if (auto* bar = ui->logTextEdit->verticalScrollBar())
+        bar->setValue(bar->maximum());
+}
+
+void MainWindow::displayStlFile(const QString& filePath)
+{
+    if (filePath.isEmpty())
+        return;
+
+    QFileInfo info(filePath);
+    if (!info.exists())
+    {
+        appendLogMessage(tr("未找到 STL 文件：%1")
+                             .arg(QDir::toNativeSeparators(filePath)));
+        return;
+    }
+
+    auto reader = vtkSmartPointer<vtkSTLReader>::New();
+    reader->SetFileName(qPrintable(info.absoluteFilePath()));
+    reader->Update();
+
+    auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+    mapper->SetInputConnection(reader->GetOutputPort());
+
+    auto actor = vtkSmartPointer<vtkActor>::New();
+    actor->SetMapper(mapper);
+    actor->GetProperty()->SetColor(0.2, 0.45, 0.75);
+    actor->GetProperty()->SetDiffuse(0.8);
+    actor->GetProperty()->SetSpecular(0.3);
+
+    if (!m_renderer)
+        return;
+
+    m_renderer->RemoveAllViewProps();
+    m_currentActor = actor;
+    m_renderer->AddActor(actor);
+    m_renderer->ResetCamera();
+    if (ui->vtkWidget && ui->vtkWidget->renderWindow())
+        ui->vtkWidget->renderWindow()->Render();
+}
+
+void MainWindow::clearVtkScene()
+{
+    if (!m_renderer)
+        return;
+    m_renderer->RemoveAllViewProps();
+    if (ui->vtkWidget && ui->vtkWidget->renderWindow())
+        ui->vtkWidget->renderWindow()->Render();
+    m_currentActor = nullptr;
+}
+
+bool MainWindow::loadSchemesFromStorage()
+{
+    QFile file(m_storageFilePath);
+    if (!file.exists())
+        return false;
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+
+    const QByteArray data = file.readAll();
+    file.close();
+
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject())
+        return false;
+
+    const QJsonObject root = doc.object();
+    const QString storedRoot = root.value(QStringLiteral("workspaceRoot")).toString();
+    if (!storedRoot.isEmpty())
+        m_workspaceRoot = storedRoot;
+    ensureDirectoryExists(m_workspaceRoot);
+
+    QVector<SchemeRecord> loaded;
+    const QJsonArray schemeArray = root.value(QStringLiteral("schemes")).toArray();
+    for (const QJsonValue& value : schemeArray)
+    {
+        const QJsonObject obj = value.toObject();
+        SchemeRecord scheme;
+        scheme.id = obj.value(QStringLiteral("id")).toString();
+        if (scheme.id.isEmpty())
+            scheme.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        scheme.name = obj.value(QStringLiteral("name")).toString();
+        scheme.workingDirectory = canonicalPathForDir(QDir(obj.value(QStringLiteral("workingDirectory")).toString()));
+        if (scheme.workingDirectory.isEmpty())
+            continue;
+
+        const QJsonArray modelArray = obj.value(QStringLiteral("models")).toArray();
+        for (const QJsonValue& mv : modelArray)
+        {
+            const QJsonObject mo = mv.toObject();
+            ModelRecord model;
+            model.id = mo.value(QStringLiteral("id")).toString();
+            if (model.id.isEmpty())
+                model.id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+            model.name = mo.value(QStringLiteral("name")).toString();
+            model.directory = canonicalPathForDir(QDir(mo.value(QStringLiteral("directory")).toString()));
+            model.jsonPath = QDir::cleanPath(mo.value(QStringLiteral("jsonPath")).toString());
+            model.batPath = QDir::cleanPath(mo.value(QStringLiteral("batPath")).toString());
+            if (model.directory.isEmpty() || model.jsonPath.isEmpty())
+                continue;
+            scheme.models.push_back(model);
+        }
+        loaded.push_back(scheme);
+    }
+
+    m_schemes = loaded;
+    return true;
+}
+
+void MainWindow::saveSchemesToStorage() const
+{
+    if (m_storageFilePath.isEmpty())
+        return;
+
+    QFileInfo info(m_storageFilePath);
+    QDir dir = info.dir();
+    if (!dir.exists())
+        dir.mkpath(QStringLiteral("."));
+
+    QJsonArray schemeArray;
+    for (const SchemeRecord& scheme : m_schemes)
+    {
+        QJsonObject obj;
+        obj.insert(QStringLiteral("id"), scheme.id);
+        obj.insert(QStringLiteral("name"), scheme.name);
+        obj.insert(QStringLiteral("workingDirectory"), scheme.workingDirectory);
+
+        QJsonArray modelArray;
+        for (const ModelRecord& model : scheme.models)
+        {
+            QJsonObject mo;
+            mo.insert(QStringLiteral("id"), model.id);
+            mo.insert(QStringLiteral("name"), model.name);
+            mo.insert(QStringLiteral("directory"), model.directory);
+            mo.insert(QStringLiteral("jsonPath"), model.jsonPath);
+            mo.insert(QStringLiteral("batPath"), model.batPath);
+            modelArray.append(mo);
+        }
+        obj.insert(QStringLiteral("models"), modelArray);
+        schemeArray.append(obj);
+    }
+
+    QJsonObject root;
+    root.insert(QStringLiteral("workspaceRoot"), m_workspaceRoot);
+    root.insert(QStringLiteral("schemes"), schemeArray);
+
+    QFile file(m_storageFilePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+        return;
+
+    QJsonDocument doc(root);
+    file.write(doc.toJson(QJsonDocument::Indented));
+    file.close();
+}
+
+void MainWindow::persistSchemes() const
+{
+    saveSchemesToStorage();
+}
+
+QString MainWindow::makeUniqueWorkspaceSubdir(const QString& baseName) const
+{
+    QDir base(workspaceRoot());
+    if (!base.exists())
+        ensureDirectoryExists(base.absolutePath());
+    QString sanitized = baseName;
+    sanitized.replace(QRegularExpression("\\s+"), "_");
+    if (sanitized.isEmpty())
+        sanitized = QStringLiteral("Workspace");
+
+    QString candidate = base.filePath(sanitized);
+    int index = 1;
+    while (QDir(candidate).exists())
+    {
+        candidate = base.filePath(QStringLiteral("%1_%2").arg(sanitized).arg(index++));
+    }
+    return candidate;
+}
+
+QString MainWindow::workspaceRoot() const
+{
+    return m_workspaceRoot;
 }

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,11 @@
+<RCC>
+    <qresource prefix="/icons">
+        <file>icons/app_logo.svg</file>
+        <file>icons/add.svg</file>
+        <file>icons/model_add.svg</file>
+        <file>icons/folder.svg</file>
+        <file>icons/gallery.svg</file>
+        <file>icons/plan.svg</file>
+        <file>icons/model.svg</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
## Summary
- redesign the main window layout with gallery navigation, toolbar buttons, a VTK preview panel, and extensive helpers for workspace persistence and model management
- enhance scheme and model settings flows, including dialogs and JSON-driven pages that emit log updates, detect new STL exports, and hand off results to the main window for rendering
- add the Qt resource collection and SVG icon set required by the updated UI components and build configuration

## Testing
- `qmake -v` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb0864fd4832da3f6d574508cba2d