### PR TITLE
完善方案卡片的布局与样式

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -53,6 +53,7 @@ private:
         QString id;
         QString name;
         QString workingDirectory;
+        QString thumbnailPath;
         QVector<ModelRecord> models;
     };
 
@@ -101,6 +102,10 @@ private:
     bool isModelFolder(const QDir& dir, QString* jsonPath, QString* batPath) const;
     QVector<ModelRecord> scanSchemeFolder(const QString& schemeDir) const;
     QPixmap makeSchemePlaceholder(const QString& name) const;
+    QPixmap loadSchemeThumbnail(const SchemeRecord& scheme) const;
+    void applySchemeThumbnail(SchemeRecord& scheme, const QString& sourcePath);
+    QString storeSchemeThumbnail(const QString& schemeDir, const QString& sourcePath) const;
+    bool isPathWithinDirectory(const QString& filePath, const QString& directory) const;
     void promptAddScheme();
     void promptAddModel(const QString& schemeId);
     void openSchemeSettings(const QString& schemeId);

--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -1,47 +1,85 @@
 ﻿#include "SchemeCardWidget.h"
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QToolButton>
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <QStyle>
+#include <QSizePolicy>
+#include <QSizeF>
+#include <QGraphicsDropShadowEffect>
+#include <QColor>
 
 SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     : QFrame(parent), m_id(id)
 {
     setObjectName("schemeCard");
     setFrameShape(QFrame::NoFrame);
+    setCursor(Qt::PointingHandCursor);
     setStyleSheet(
-        "#schemeCard{background:#ffffff;border:1px solid #e5e5e5;"
-        "border-radius:10px;}"
+        "#schemeCard{background:#ffffff;border:1px solid #e4e7f1;"
+        "border-radius:14px;}"
         "#schemeCard:hover{border:1px solid #1787ff;}"
-        "QLabel#title{padding:6px 8px;font-weight:600;}"
-    );
-    setMinimumSize(220, 220);
+        "QLabel#titleLabel{font-weight:600;font-size:15px;color:#1b2b4d;}"
+        "QLabel#hintLabel{color:#8a93a6;font-size:12px;}"
+        "QLabel#imageLabel{background:#f6f7fb;border-radius:12px;"
+        "border:1px dashed #d0d6e5;color:#8a93a6;font-size:13px;"
+        "padding:12px;line-height:20px;}"
+        "QToolButton#deleteButton{border:none;border-radius:12px;"
+        "padding:4px;color:#d93025;"
+        "background:rgba(217,48,37,0.08);}"
+        "QToolButton#deleteButton:hover{background:rgba(217,48,37,0.16);}" );
+
+    auto* shadow = new QGraphicsDropShadowEffect(this);
+    shadow->setBlurRadius(24);
+    shadow->setOffset(0, 8);
+    shadow->setColor(QColor(27, 43, 77, 30));
+    setGraphicsEffect(shadow);
+
+    setMinimumSize(240, 300);
 
     auto *lay = new QVBoxLayout(this);
-    lay->setContentsMargins(8,8,8,8);
-    lay->setSpacing(6);
+    lay->setContentsMargins(16,16,16,16);
+    lay->setSpacing(12);
 
-    m_imageLabel = new QLabel(this);
-    m_imageLabel->setMinimumSize(200,140);
-    m_imageLabel->setAlignment(Qt::AlignCenter);
-    m_imageLabel->setStyleSheet("background:#f6f7fb;border-radius:6px;");
-    m_imageLabel->setScaledContents(false);
-    lay->addWidget(m_imageLabel, /*stretch*/1);
+    auto *header = new QHBoxLayout();
+    header->setContentsMargins(0,0,0,0);
+    header->setSpacing(8);
 
     m_titleLabel = new QLabel(this);
-    m_titleLabel->setObjectName("title");
-    m_titleLabel->setAlignment(Qt::AlignCenter);
-    lay->addWidget(m_titleLabel);
+    m_titleLabel->setObjectName("titleLabel");
+    m_titleLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_titleLabel->setWordWrap(true);
+    m_titleLabel->setText(tr("未命名方案"));
+    header->addWidget(m_titleLabel, 1);
 
     m_deleteBtn = new QToolButton(this);
-    m_deleteBtn->setToolTip("删除此方案");
-    m_deleteBtn->setText("×");
-    m_deleteBtn->setAutoRaise(true);
-    m_deleteBtn->setStyleSheet("QToolButton{font-size:16px;}");
-    m_deleteBtn->setFixedSize(24,24);
-    m_deleteBtn->move(width()-28, 4);
-    m_deleteBtn->raise();
+    m_deleteBtn->setObjectName("deleteButton");
+    m_deleteBtn->setToolTip(tr("删除此方案"));
+    m_deleteBtn->setIcon(style()->standardIcon(QStyle::SP_TrashIcon));
+    m_deleteBtn->setIconSize(QSize(16, 16));
+    m_deleteBtn->setAutoRaise(false);
+    m_deleteBtn->setCursor(Qt::ArrowCursor);
+    header->addWidget(m_deleteBtn, 0, Qt::AlignRight);
+
+    lay->addLayout(header);
+
+    m_imageLabel = new QLabel(this);
+    m_imageLabel->setObjectName("imageLabel");
+    m_imageLabel->setMinimumSize(220,160);
+    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_imageLabel->setAlignment(Qt::AlignCenter);
+    m_imageLabel->setWordWrap(true);
+    m_imageLabel->setText(tr("暂无封面"));
+    lay->addWidget(m_imageLabel, /*stretch*/1);
+
+    m_hintLabel = new QLabel(this);
+    m_hintLabel->setObjectName("hintLabel");
+    m_hintLabel->setAlignment(Qt::AlignCenter);
+    m_hintLabel->setWordWrap(true);
+    m_hintLabel->setText(tr("点击卡片以查看详情"));
+    lay->addWidget(m_hintLabel);
 
     connect(m_deleteBtn, &QToolButton::clicked, this, [this](){
         emit deleteRequested(m_id);
@@ -54,9 +92,8 @@ void SchemeCardWidget::setTitle(const QString& title) {
 QString SchemeCardWidget::title() const { return m_titleLabel->text(); }
 
 void SchemeCardWidget::setThumbnail(const QPixmap& pm) {
-    // 居中等比显示
-    QPixmap scaled = pm.scaled(m_imageLabel->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    m_imageLabel->setPixmap(scaled);
+    m_thumbnail = pm;
+    updateThumbnailDisplay();
 }
 
 void SchemeCardWidget::mousePressEvent(QMouseEvent* ev) {
@@ -64,4 +101,35 @@ void SchemeCardWidget::mousePressEvent(QMouseEvent* ev) {
         emit openRequested(m_id);
     }
     QFrame::mousePressEvent(ev);
+}
+
+void SchemeCardWidget::resizeEvent(QResizeEvent* ev)
+{
+    QFrame::resizeEvent(ev);
+    updateThumbnailDisplay();
+}
+
+void SchemeCardWidget::updateThumbnailDisplay()
+{
+    if (!m_imageLabel)
+        return;
+
+    if (m_thumbnail.isNull())
+    {
+        m_imageLabel->setPixmap(QPixmap());
+        m_imageLabel->setText(tr("暂无封面"));
+        return;
+    }
+
+    m_imageLabel->setText(QString());
+    const QSize labelSize = m_imageLabel->size();
+    if (labelSize.width() <= 0 || labelSize.height() <= 0)
+        return;
+
+    const qreal ratio = devicePixelRatioF();
+    const QSize targetSize = (QSizeF(labelSize) * ratio).toSize();
+    QPixmap scaled = m_thumbnail.scaled(targetSize, Qt::KeepAspectRatio,
+                                        Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(ratio);
+    m_imageLabel->setPixmap(scaled);
 }

--- a/SchemeCardWidget.h
+++ b/SchemeCardWidget.h
@@ -22,10 +22,15 @@ signals:
 
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
+    void resizeEvent(QResizeEvent* ev) override;
 
 private:
+    void updateThumbnailDisplay();
+
     QString m_id;
     QLabel* m_imageLabel;
     QLabel* m_titleLabel;
     QToolButton* m_deleteBtn;
+    QLabel* m_hintLabel;
+    QPixmap m_thumbnail;
 };

--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -87,11 +87,21 @@ void SchemeGalleryWidget::relayoutCards() {
         delete it;
     }
 
+    grid->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+
     // 计算列数（根据可视宽度自适应换行）
     int viewportW = ui->scrollArea->viewport()->width();
     int hSpacing = grid->horizontalSpacing();
     int contents = grid->contentsMargins().left() + grid->contentsMargins().right();
-    int cols = qMax(1, (viewportW - contents + hSpacing) / (m_cardW + hSpacing));
+    int cardWidth = m_cardW;
+    for (const auto& card : m_cards) {
+        if (card) {
+            cardWidth = qMax(cardWidth, card->sizeHint().width());
+            break;
+        }
+    }
+
+    int cols = qMax(1, (viewportW - contents + hSpacing) / (cardWidth + hSpacing));
 
     int row = 0, col = 0;
     for (QPointer<SchemeCardWidget> card : m_cards) {

--- a/SchemeGalleryWidget.h
+++ b/SchemeGalleryWidget.h
@@ -33,5 +33,5 @@ private:
 private:
     Ui::SchemeGalleryWidget *ui;
     QList<QPointer<SchemeCardWidget>> m_cards;
-    int m_cardW = 236;                // 估算卡片宽度（含间距）
+    int m_cardW = 268;                // 估算卡片宽度（含间距）
 };

--- a/SchemeSettingsDialog.cpp
+++ b/SchemeSettingsDialog.cpp
@@ -7,16 +7,21 @@
 #include <QPushButton>
 #include <QFileDialog>
 #include <QDir>
+#include <QImageReader>
+#include <QResizeEvent>
+#include <QFileInfo>
+#include <QPixmap>
 
 SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
                                            const QString& workingDirectory,
                                            bool allowDirectoryChange,
-                                           QWidget* parent)
+                                           QWidget* parent,
+                                           const QString& thumbnailPath)
     : QDialog(parent)
     , m_directoryEditable(allowDirectoryChange)
 {
     setWindowTitle(tr("方案设置"));
-    resize(480, 240);
+    resize(520, 360);
 
     auto* v = new QVBoxLayout(this);
     v->setContentsMargins(16, 16, 16, 16);
@@ -34,6 +39,7 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     v->addLayout(nameRow);
 
     auto* dirRow = new QHBoxLayout();
+    dirRow->setSpacing(8);
     dirRow->addWidget(new QLabel(tr("工作目录："), this));
     m_directoryEdit = new QLineEdit(workingDirectory, this);
     m_directoryEdit->setPlaceholderText(tr("请选择模型计算的工作目录"));
@@ -47,10 +53,48 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     if (allowDirectoryChange)
         connect(m_browseButton, &QPushButton::clicked, this, &SchemeSettingsDialog::browseForDirectory);
 
+    auto* thumbTitle = new QLabel(tr("方案封面"), this);
+    thumbTitle->setStyleSheet("font-weight:600;");
+    v->addWidget(thumbTitle);
+
+    auto* thumbRow = new QHBoxLayout();
+    thumbRow->setContentsMargins(0, 0, 0, 0);
+    thumbRow->setSpacing(12);
+
+    m_thumbnailPreview = new QLabel(this);
+    m_thumbnailPreview->setMinimumSize(260, 160);
+    m_thumbnailPreview->setAlignment(Qt::AlignCenter);
+    m_thumbnailPreview->setWordWrap(true);
+    m_thumbnailPreview->setStyleSheet("background:#f6f7fb;"
+                                      "border:1px dashed #d0d6e5;"
+                                      "border-radius:8px;"
+                                      "color:#8a93a6;"
+                                      "padding:12px;line-height:20px;");
+    thumbRow->addWidget(m_thumbnailPreview, 1);
+
+    auto* thumbButtons = new QVBoxLayout();
+    thumbButtons->setContentsMargins(0, 0, 0, 0);
+    thumbButtons->setSpacing(8);
+    m_thumbnailButton = new QPushButton(tr("选择图片..."), this);
+    thumbButtons->addWidget(m_thumbnailButton);
+    m_clearThumbnailButton = new QPushButton(tr("清除图片"), this);
+    thumbButtons->addWidget(m_clearThumbnailButton);
+    thumbButtons->addStretch(1);
+    thumbRow->addLayout(thumbButtons, 0);
+
+    v->addLayout(thumbRow);
+
+    connect(m_thumbnailButton, &QPushButton::clicked,
+            this, &SchemeSettingsDialog::browseForThumbnail);
+    connect(m_clearThumbnailButton, &QPushButton::clicked,
+            this, &SchemeSettingsDialog::clearThumbnail);
+
     auto* btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     connect(btns, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(btns, &QDialogButtonBox::rejected, this, &QDialog::reject);
     v->addWidget(btns);
+
+    setThumbnailPath(thumbnailPath);
 }
 
 QString SchemeSettingsDialog::schemeName() const
@@ -61,6 +105,11 @@ QString SchemeSettingsDialog::schemeName() const
 QString SchemeSettingsDialog::workingDirectory() const
 {
     return m_directoryEdit ? QDir::cleanPath(m_directoryEdit->text().trimmed()) : QString();
+}
+
+QString SchemeSettingsDialog::thumbnailPath() const
+{
+    return m_thumbnailPath;
 }
 
 void SchemeSettingsDialog::setSchemeName(const QString& name)
@@ -77,6 +126,16 @@ void SchemeSettingsDialog::setWorkingDirectory(const QString& directory)
         m_directoryEdit->setText(QDir::toNativeSeparators(directory));
 }
 
+void SchemeSettingsDialog::setThumbnailPath(const QString& path)
+{
+    const QString trimmed = path.trimmed();
+    if (trimmed.isEmpty())
+        m_thumbnailPath.clear();
+    else
+        m_thumbnailPath = QDir::cleanPath(QFileInfo(trimmed).absoluteFilePath());
+    updateThumbnailPreview();
+}
+
 void SchemeSettingsDialog::browseForDirectory()
 {
     if (!m_directoryEditable)
@@ -86,4 +145,66 @@ void SchemeSettingsDialog::browseForDirectory()
                                                           workingDirectory());
     if (!dir.isEmpty())
         setWorkingDirectory(dir);
+}
+
+void SchemeSettingsDialog::browseForThumbnail()
+{
+    const QString initialDir = m_thumbnailPath.isEmpty()
+                                   ? workingDirectory()
+                                   : QFileInfo(m_thumbnailPath).absolutePath();
+    const QString file = QFileDialog::getOpenFileName(
+        this, tr("选择封面图片"), initialDir,
+        tr("图片文件 (*.png *.jpg *.jpeg *.bmp *.gif)"));
+    if (!file.isEmpty())
+        setThumbnailPath(file);
+}
+
+void SchemeSettingsDialog::clearThumbnail()
+{
+    if (m_thumbnailPath.isEmpty())
+        return;
+    m_thumbnailPath.clear();
+    updateThumbnailPreview();
+}
+
+void SchemeSettingsDialog::resizeEvent(QResizeEvent* event)
+{
+    QDialog::resizeEvent(event);
+    updateThumbnailPreview();
+}
+
+void SchemeSettingsDialog::updateThumbnailPreview()
+{
+    if (!m_thumbnailPreview)
+        return;
+
+    QPixmap pixmap;
+    if (!m_thumbnailPath.isEmpty())
+    {
+        QImageReader reader(m_thumbnailPath);
+        reader.setAutoTransform(true);
+        const QImage image = reader.read();
+        if (!image.isNull())
+            pixmap = QPixmap::fromImage(image);
+    }
+
+    if (pixmap.isNull())
+    {
+        m_thumbnailPreview->setPixmap(QPixmap());
+        m_thumbnailPreview->setText(tr("尚未选择封面图片"));
+    }
+    else
+    {
+        m_thumbnailPreview->setText(QString());
+        const QSize labelSize = m_thumbnailPreview->size();
+        if (labelSize.width() > 0 && labelSize.height() > 0)
+        {
+            const QPixmap scaled = pixmap.scaled(labelSize, Qt::KeepAspectRatio,
+                                                 Qt::SmoothTransformation);
+            m_thumbnailPreview->setPixmap(scaled);
+        }
+    }
+
+    if (m_clearThumbnailButton)
+        m_clearThumbnailButton->setEnabled(!m_thumbnailPath.isEmpty());
 }

--- a/SchemeSettingsDialog.h
+++ b/SchemeSettingsDialog.h
@@ -12,20 +12,34 @@ public:
     explicit SchemeSettingsDialog(const QString& schemeName,
                                   const QString& workingDirectory = QString(),
                                   bool allowDirectoryChange = true,
-                                  QWidget* parent = nullptr);
+                                  QWidget* parent = nullptr,
+                                  const QString& thumbnailPath = QString());
 
     QString schemeName() const;
     QString workingDirectory() const;
+    QString thumbnailPath() const;
     void setSchemeName(const QString& name);
     void setWorkingDirectory(const QString& directory);
+    void setThumbnailPath(const QString& path);
 
 private slots:
     void browseForDirectory();
+    void browseForThumbnail();
+    void clearThumbnail();
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
+    void updateThumbnailPreview();
+
     QLabel* m_title = nullptr;
     QLineEdit* m_nameEdit = nullptr;
     QLineEdit* m_directoryEdit = nullptr;
     QPushButton* m_browseButton = nullptr;
+    QLabel* m_thumbnailPreview = nullptr;
+    QPushButton* m_thumbnailButton = nullptr;
+    QPushButton* m_clearThumbnailButton = nullptr;
+    QString m_thumbnailPath;
     bool m_directoryEditable = true;
 };


### PR DESCRIPTION
## Summary
- 将方案卡片的标题与操作按钮集中在卡片顶部，并为封面图和提示文案提供更协调的布局
- 为卡片增加投影、圆角与色彩统一的按钮样式，突出封面图片的展示效果
- 调整方案库网格的排布逻辑以适配新的卡片尺寸并保持顶部对齐

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbdb87665c832db7240a8bcd3f17ac