### PR TITLE
Fix gallery layout sizing and confirm deletions

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -111,6 +111,8 @@ private:
     void openSchemeSettings(const QString& schemeId);
     void removeSchemeById(const QString& id);
     void removeModelById(const QString& id);
+    bool confirmSchemeDeletion(const SchemeRecord& scheme);
+    bool confirmModelDeletion(const ModelRecord& model, const SchemeRecord& owner);
     void syncDataFromTree();
     bool loadSchemesFromStorage();
     void saveSchemesToStorage() const;

--- a/SchemeGalleryWidget.h
+++ b/SchemeGalleryWidget.h
@@ -34,4 +34,5 @@ private:
     Ui::SchemeGalleryWidget *ui;
     QList<QPointer<SchemeCardWidget>> m_cards;
     int m_cardW = 268;                // 估算卡片宽度（含间距）
+    int m_lastColumnCount = 0;
 };


### PR DESCRIPTION
## Summary
- ensure scheme cards expand evenly and relayout without requiring manual window resize
- add confirmation prompts before deleting schemes or models from the gallery and tree views

## Testing
- not run (Qt application tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbea73be04832d9ba0bb9c46a7c9d6