### PR TITLE
Add project-based workspace management

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -7,6 +7,7 @@
 #include <QPixmap>
 #include <QUrl>
 #include <QDir>
+#include <QPair>
 #include <vtkSmartPointer.h>
 
 QT_BEGIN_NAMESPACE
@@ -39,6 +40,8 @@ private slots:
     void onGalleryOpenRequested(const QString& id);
     void onGalleryDeleteRequested(const QString& id);
     void deleteCurrentTreeItem();
+    void onNewProjectTriggered();
+    void onOpenProjectTriggered();
 
 private:
     struct ModelRecord {
@@ -71,6 +74,12 @@ private:
     void setupUiHelpers();
     void setupConnections();
     void loadInitialSchemes();
+    void loadApplicationState();
+    void saveApplicationState() const;
+    void enterProjectlessState();
+    bool openProjectAt(const QString& path, bool silent = false);
+    bool ensureProjectStructure(const QString& rootPath);
+    void updateWindowTitle();
 
     void refreshNavigation(const QString& schemeToSelect = QString(),
                            const QString& modelToSelect = QString());
@@ -106,6 +115,9 @@ private:
     void applySchemeThumbnail(SchemeRecord& scheme, const QString& sourcePath);
     QString storeSchemeThumbnail(const QString& schemeDir, const QString& sourcePath) const;
     bool isPathWithinDirectory(const QString& filePath, const QString& directory) const;
+    QVector<QPair<QString, QString>> availableSchemeTemplates() const;
+    QStringList templateSearchRoots() const;
+    bool hasActiveProject() const;
     void promptAddScheme();
     void promptAddModel(const QString& schemeId);
     void openSchemeSettings(const QString& schemeId);
@@ -129,8 +141,11 @@ private:
     QString m_activeSchemeId;
     QString m_activeModelId;
     bool m_blockTreeSignals = false;
+    QString m_appStateFilePath;
+    QString m_projectRoot;
     QString m_storageFilePath;
     QString m_workspaceRoot;
+    QString m_baseWindowTitle;
     vtkSmartPointer<vtkGenericOpenGLRenderWindow> m_renderWindow;
     vtkSmartPointer<vtkRenderer> m_renderer;
     vtkSmartPointer<vtkActor> m_currentActor;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -254,8 +254,75 @@
       </widget>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
+       <widget class="QWidget" name="welcomePage">
+        <layout class="QVBoxLayout" name="welcomeLayout">
+         <property name="spacing">
+          <number>12</number>
+         </property>
+         <property name="leftMargin">
+          <number>24</number>
+         </property>
+         <property name="topMargin">
+          <number>24</number>
+         </property>
+         <property name="rightMargin">
+          <number>24</number>
+         </property>
+         <property name="bottomMargin">
+          <number>24</number>
+         </property>
+         <item>
+          <spacer name="welcomeTopSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>120</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="welcomeLabel">
+           <property name="text">
+            <string>当前未打开任何工程，请通过“工程”菜单新建或打开工程。</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignVCenter</set>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">font-size:16px;color:#4b5563;</string>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>80</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="welcomeBottomSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>120</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
        <widget class="QWidget" name="planPage">
         <layout class="QVBoxLayout" name="planPageLayout">
          <property name="spacing">
@@ -512,6 +579,8 @@
     <property name="title">
      <string>工程(&amp;P)</string>
     </property>
+    <addaction name="actionNewProject"/>
+    <addaction name="actionOpenProject"/>
    </widget>
    <widget class="QMenu" name="menuModel">
     <property name="title">
@@ -521,8 +590,18 @@
    <addaction name="menuProject"/>
    <addaction name="menuModel"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
- </widget>
+ <widget class="QStatusBar" name="statusbar"/>
+ <action name="actionNewProject">
+  <property name="text">
+   <string>新建工程...</string>
+  </property>
+ </action>
+ <action name="actionOpenProject">
+  <property name="text">
+   <string>打开工程...</string>
+  </property>
+ </action>
+</widget>
  <customwidgets>
   <customwidget>
    <class>SchemeTreeWidget</class>

--- a/SchemeSettingsDialog.cpp
+++ b/SchemeSettingsDialog.cpp
@@ -126,6 +126,12 @@ void SchemeSettingsDialog::setWorkingDirectory(const QString& directory)
         m_directoryEdit->setText(QDir::toNativeSeparators(directory));
 }
 
+void SchemeSettingsDialog::setDirectoryHint(const QString& hint)
+{
+    if (m_directoryEdit)
+        m_directoryEdit->setPlaceholderText(hint);
+}
+
 void SchemeSettingsDialog::setThumbnailPath(const QString& path)
 {
     const QString trimmed = path.trimmed();

--- a/SchemeSettingsDialog.h
+++ b/SchemeSettingsDialog.h
@@ -21,6 +21,7 @@ public:
     void setSchemeName(const QString& name);
     void setWorkingDirectory(const QString& directory);
     void setThumbnailPath(const QString& path);
+    void setDirectoryHint(const QString& hint);
 
 private slots:
     void browseForDirectory();


### PR DESCRIPTION
## Summary
- introduce project-centric workflow with actions to create or open an engineering workspace and persist the selection
- show a welcome page when no project is loaded and disable plan interactions until a project is active
- streamline scheme creation by auto-generating working directories, offering template selection, and updating the settings dialog hints

## Testing
- not run (Qt tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ccc1392ed4832d948142912fc738f8