### PR TITLE
Add shared scheme library management

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -38,10 +38,12 @@ private slots:
     void onTreeItemsReordered();
     void onExternalDrop(const QList<QUrl>& urls, QTreeWidgetItem* target);
     void onGalleryOpenRequested(const QString& id);
+    void onGalleryAddRequested(const QString& id);
     void onGalleryDeleteRequested(const QString& id);
     void deleteCurrentTreeItem();
     void onNewProjectTriggered();
     void onOpenProjectTriggered();
+    void onAddLibraryScheme();
 
 private:
     struct ModelRecord {
@@ -50,6 +52,14 @@ private:
         QString directory;
         QString jsonPath;
         QString batPath;
+    };
+
+    struct SchemeLibraryEntry {
+        QString id;
+        QString name;
+        QString directory;
+        QString thumbnailPath;
+        bool deletable = false;
     };
 
     struct SchemeRecord {
@@ -118,6 +128,15 @@ private:
     QVector<QPair<QString, QString>> availableSchemeTemplates() const;
     QStringList templateSearchRoots() const;
     bool hasActiveProject() const;
+    void loadSchemeLibrary();
+    void saveSchemeLibrary() const;
+    QString schemeLibraryRoot() const;
+    QString makeUniqueLibrarySubdir(const QString& baseName) const;
+    SchemeLibraryEntry* libraryEntryById(const QString& id);
+    const SchemeLibraryEntry* libraryEntryById(const QString& id) const;
+    QPixmap loadLibraryThumbnail(const SchemeLibraryEntry& entry) const;
+    void applyLibraryThumbnail(SchemeLibraryEntry& entry, const QString& sourcePath);
+    bool removeLibraryEntry(const QString& id);
     void promptAddScheme();
     void promptAddModel(const QString& schemeId);
     void openSchemeSettings(const QString& schemeId);
@@ -135,6 +154,7 @@ private:
     Ui::MainWindow *ui;
     SchemeGalleryWidget* m_galleryWidget = nullptr;
     QWidget* m_currentDetailWidget = nullptr;
+    QVector<SchemeLibraryEntry> m_librarySchemes;
     QVector<SchemeRecord> m_schemes;
     QHash<QString, QTreeWidgetItem*> m_schemeItems;
     QHash<QString, QTreeWidgetItem*> m_modelItems;
@@ -145,6 +165,7 @@ private:
     QString m_projectRoot;
     QString m_storageFilePath;
     QString m_workspaceRoot;
+    QString m_schemeLibraryRoot;
     QString m_baseWindowTitle;
     vtkSmartPointer<vtkGenericOpenGLRenderWindow> m_renderWindow;
     vtkSmartPointer<vtkRenderer> m_renderer;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -115,10 +115,10 @@
        <item>
         <widget class="QPushButton" name="addSchemeButton">
          <property name="toolTip">
-          <string>创建一个新的方案</string>
+          <string>创建一个新的方案库</string>
          </property>
          <property name="text">
-          <string>新增方案</string>
+          <string>新增方案库</string>
          </property>
          <property name="icon">
           <iconset>

--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -10,6 +10,7 @@
 #include <QSizeF>
 #include <QGraphicsDropShadowEffect>
 #include <QColor>
+#include <QIcon>
 
 SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     : QFrame(parent), m_id(id)
@@ -26,6 +27,9 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
         "QLabel#imageLabel{background:#f6f7fb;border-radius:12px;"
         "border:1px dashed #d0d6e5;color:#8a93a6;font-size:13px;"
         "padding:12px;line-height:20px;}"
+        "QToolButton#addButton{border:none;border-radius:12px;padding:4px;"
+        "color:#0b57d0;background:rgba(11,87,208,0.08);}"
+        "QToolButton#addButton:hover{background:rgba(11,87,208,0.16);}"
         "QToolButton#deleteButton{border:none;border-radius:12px;"
         "padding:4px;color:#d93025;"
         "background:rgba(217,48,37,0.08);}"
@@ -54,6 +58,16 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     m_titleLabel->setText(tr("未命名方案"));
     header->addWidget(m_titleLabel, 1);
 
+    m_addBtn = new QToolButton(this);
+    m_addBtn->setObjectName("addButton");
+    m_addBtn->setToolTip(tr("添加到当前工程"));
+    m_addBtn->setIcon(QIcon(QStringLiteral(":/icons/add.svg")));
+    m_addBtn->setIconSize(QSize(16, 16));
+    m_addBtn->setAutoRaise(false);
+    m_addBtn->setCursor(Qt::ArrowCursor);
+    m_addBtn->setVisible(false);
+    header->addWidget(m_addBtn, 0, Qt::AlignRight);
+
     m_deleteBtn = new QToolButton(this);
     m_deleteBtn->setObjectName("deleteButton");
     m_deleteBtn->setToolTip(tr("删除此方案"));
@@ -81,7 +95,10 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     m_hintLabel->setText(tr("点击卡片以查看详情"));
     lay->addWidget(m_hintLabel);
 
-    connect(m_deleteBtn, &QToolButton::clicked, this, [this](){
+    connect(m_addBtn, &QToolButton::clicked, this, [this]() {
+        emit addRequested(m_id);
+    });
+    connect(m_deleteBtn, &QToolButton::clicked, this, [this]() {
         emit deleteRequested(m_id);
     });
 }
@@ -96,10 +113,56 @@ void SchemeCardWidget::setThumbnail(const QPixmap& pm) {
     updateThumbnailDisplay();
 }
 
-void SchemeCardWidget::mousePressEvent(QMouseEvent* ev) {
-    if (!m_deleteBtn->geometry().contains(ev->pos())) {
+void SchemeCardWidget::setHintText(const QString& text)
+{
+    if (m_hintLabel)
+        m_hintLabel->setText(text);
+}
+
+void SchemeCardWidget::setAddButtonVisible(bool visible)
+{
+    if (m_addBtn)
+        m_addBtn->setVisible(visible);
+}
+
+void SchemeCardWidget::setAddButtonEnabled(bool enabled)
+{
+    if (m_addBtn)
+        m_addBtn->setEnabled(enabled);
+}
+
+void SchemeCardWidget::setDeleteButtonVisible(bool visible)
+{
+    if (m_deleteBtn)
+        m_deleteBtn->setVisible(visible);
+}
+
+void SchemeCardWidget::setDeleteButtonEnabled(bool enabled)
+{
+    if (m_deleteBtn)
+        m_deleteBtn->setEnabled(enabled);
+}
+
+void SchemeCardWidget::setAddButtonToolTip(const QString& text)
+{
+    if (m_addBtn)
+        m_addBtn->setToolTip(text);
+}
+
+void SchemeCardWidget::setDeleteButtonToolTip(const QString& text)
+{
+    if (m_deleteBtn)
+        m_deleteBtn->setToolTip(text);
+}
+
+void SchemeCardWidget::mousePressEvent(QMouseEvent* ev)
+{
+    const bool onAdd = m_addBtn && m_addBtn->isVisible() &&
+                       m_addBtn->geometry().contains(ev->pos());
+    const bool onDelete = m_deleteBtn && m_deleteBtn->isVisible() &&
+                          m_deleteBtn->geometry().contains(ev->pos());
+    if (!onAdd && !onDelete)
         emit openRequested(m_id);
-    }
     QFrame::mousePressEvent(ev);
 }
 

--- a/SchemeCardWidget.h
+++ b/SchemeCardWidget.h
@@ -14,10 +14,18 @@ public:
     QString title() const;
 
     void setThumbnail(const QPixmap& pm);
+    void setHintText(const QString& text);
+    void setAddButtonVisible(bool visible);
+    void setAddButtonEnabled(bool enabled);
+    void setDeleteButtonVisible(bool visible);
+    void setDeleteButtonEnabled(bool enabled);
+    void setAddButtonToolTip(const QString& text);
+    void setDeleteButtonToolTip(const QString& text);
     QString id() const { return m_id; }
 
 signals:
     void openRequested(const QString& id);
+    void addRequested(const QString& id);
     void deleteRequested(const QString& id);
 
 protected:
@@ -30,6 +38,7 @@ private:
     QString m_id;
     QLabel* m_imageLabel;
     QLabel* m_titleLabel;
+    QToolButton* m_addBtn;
     QToolButton* m_deleteBtn;
     QLabel* m_hintLabel;
     QPixmap m_thumbnail;

--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -31,7 +31,8 @@ void SchemeGalleryWidget::clearSchemes()
 
 void SchemeGalleryWidget::addScheme(const QString& id,
                                     const QString& name,
-                                    const QPixmap& thumb) {
+                                    const QPixmap& thumb,
+                                    const CardOptions& options) {
     if (id.isEmpty())
         return;
 
@@ -42,6 +43,16 @@ void SchemeGalleryWidget::addScheme(const QString& id,
     card->setTitle(name.isEmpty() ? QStringLiteral("未命名方案") : name);
     if (!thumb.isNull()) card->setThumbnail(thumb);
     card->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    if (!options.hintText.isEmpty())
+        card->setHintText(options.hintText);
+    card->setAddButtonVisible(options.showAddButton);
+    card->setAddButtonEnabled(options.enableAddButton);
+    if (!options.addToolTip.isEmpty())
+        card->setAddButtonToolTip(options.addToolTip);
+    card->setDeleteButtonVisible(options.showDeleteButton);
+    card->setDeleteButtonEnabled(options.enableDeleteButton);
+    if (!options.deleteToolTip.isEmpty())
+        card->setDeleteButtonToolTip(options.deleteToolTip);
 
     // 放进网格
     auto* grid = qobject_cast<QGridLayout*>(ui->gridLayout);
@@ -51,6 +62,9 @@ void SchemeGalleryWidget::addScheme(const QString& id,
     // 打开设置
     connect(card, &SchemeCardWidget::openRequested,
             this, &SchemeGalleryWidget::schemeOpenRequested);
+
+    connect(card, &SchemeCardWidget::addRequested,
+            this, &SchemeGalleryWidget::schemeAddRequested);
 
     // 删除
     connect(card, &SchemeCardWidget::deleteRequested,

--- a/SchemeGalleryWidget.h
+++ b/SchemeGalleryWidget.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include <QWidget>
 #include <QPointer>
+#include <QString>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class SchemeGalleryWidget; }
@@ -14,14 +15,26 @@ public:
     explicit SchemeGalleryWidget(QWidget *parent = nullptr);
     ~SchemeGalleryWidget();
 
+    struct CardOptions {
+        bool showAddButton = false;
+        bool enableAddButton = true;
+        bool showDeleteButton = true;
+        bool enableDeleteButton = true;
+        QString hintText;
+        QString addToolTip;
+        QString deleteToolTip;
+    };
+
     void clearSchemes();
     void addScheme(const QString& id,
                    const QString& name = QString(),
-                   const QPixmap& thumb = QPixmap());
+                   const QPixmap& thumb = QPixmap(),
+                   const CardOptions& options = CardOptions());
     void removeSchemeById(const QString& id);
 
 signals:
     void schemeOpenRequested(const QString& id);
+    void schemeAddRequested(const QString& id);
     void schemeDeleteRequested(const QString& id);
 
 protected:


### PR DESCRIPTION
## Summary
- add persistent scheme library management under the application directory and load it alongside built-in templates
- expose manual add/remove actions in the scheme gallery with a new add button on each card
- repurpose the “新增方案库” button to create reusable library entries without touching the current project

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cccca11a1c832d8fbb11fb34a6bc93