### PR TITLE
Improve scheme navigation and gallery interactions

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -77,7 +77,8 @@ private:
     };
 
     enum TreeItemType {
-        SchemeItem = 1,
+        ProjectItem = 0,
+        SchemeItem,
         ModelItem
     };
 
@@ -106,6 +107,7 @@ private:
     void appendLogMessage(const QString& message);
     void displayStlFile(const QString& filePath);
     void clearVtkScene();
+    QString projectDisplayName() const;
 
     SchemeRecord* schemeById(const QString& id);
     const SchemeRecord* schemeById(const QString& id) const;
@@ -145,6 +147,14 @@ private:
     bool confirmSchemeDeletion(const SchemeRecord& scheme);
     bool confirmModelDeletion(const ModelRecord& model, const SchemeRecord& owner);
     void syncDataFromTree();
+    QString makeUniqueName(const QString& desired, QSet<QString>& taken,
+                           const QString& fallback) const;
+    QString makeUniqueSchemeName(const QString& desired,
+                                 const QString& excludeId = QString()) const;
+    QString makeUniqueModelName(const SchemeRecord& scheme, const QString& desired,
+                                const QString& excludeId = QString()) const;
+    void ensureUniqueModelNames(SchemeRecord& scheme) const;
+    void ensureUniqueSchemeAndModelNames();
     bool loadSchemesFromStorage();
     void saveSchemesToStorage() const;
     void persistSchemes() const;
@@ -158,6 +168,7 @@ private:
     QVector<SchemeRecord> m_schemes;
     QHash<QString, QTreeWidgetItem*> m_schemeItems;
     QHash<QString, QTreeWidgetItem*> m_modelItems;
+    QTreeWidgetItem* m_projectRootItem = nullptr;
     QString m_activeSchemeId;
     QString m_activeModelId;
     bool m_blockTreeSignals = false;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -69,7 +69,7 @@
           </size>
          </property>
          <property name="pixmap">
-          <pixmap>:/icons/app_logo.svg</pixmap>
+          <pixmap>:/icons/icons/app_logo.svg</pixmap>
          </property>
          <property name="scaledContents">
           <bool>true</bool>
@@ -102,7 +102,7 @@
          </property>
          <property name="icon">
           <iconset>
-           <normaloff>:/icons/gallery.svg</normaloff>:/icons/gallery.svg</iconset>
+           <normaloff>:/icons/icons/gallery.svg</normaloff>:/icons/icons/gallery.svg</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -122,7 +122,7 @@
          </property>
          <property name="icon">
           <iconset>
-           <normaloff>:/icons/add.svg</normaloff>:/icons/add.svg</iconset>
+           <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -145,7 +145,7 @@
          </property>
          <property name="icon">
           <iconset>
-           <normaloff>:/icons/model_add.svg</normaloff>:/icons/model_add.svg</iconset>
+           <normaloff>:/icons/icons/model_add.svg</normaloff>:/icons/icons/model_add.svg</iconset>
          </property>
          <property name="iconSize">
           <size>
@@ -168,7 +168,7 @@
          </property>
          <property name="icon">
           <iconset>
-           <normaloff>:/icons/folder.svg</normaloff>:/icons/folder.svg</iconset>
+           <normaloff>:/icons/icons/folder.svg</normaloff>:/icons/icons/folder.svg</iconset>
          </property>
          <property name="iconSize">
           <size>

--- a/SchemeCardWidget.h
+++ b/SchemeCardWidget.h
@@ -21,6 +21,9 @@ public:
     void setDeleteButtonEnabled(bool enabled);
     void setAddButtonToolTip(const QString& text);
     void setDeleteButtonToolTip(const QString& text);
+    void setOpenButtonVisible(bool visible);
+    void setOpenButtonEnabled(bool enabled);
+    void setOpenButtonToolTip(const QString& text);
     QString id() const { return m_id; }
 
 signals:
@@ -30,16 +33,19 @@ signals:
 
 protected:
     void mousePressEvent(QMouseEvent* ev) override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) override;
     void resizeEvent(QResizeEvent* ev) override;
 
 private:
     void updateThumbnailDisplay();
+    bool isPointInsideButton(const QToolButton* button, const QPoint& pos) const;
 
     QString m_id;
     QLabel* m_imageLabel;
     QLabel* m_titleLabel;
     QToolButton* m_addBtn;
     QToolButton* m_deleteBtn;
+    QToolButton* m_openBtn;
     QLabel* m_hintLabel;
     QPixmap m_thumbnail;
 };

--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -53,6 +53,10 @@ void SchemeGalleryWidget::addScheme(const QString& id,
     card->setDeleteButtonEnabled(options.enableDeleteButton);
     if (!options.deleteToolTip.isEmpty())
         card->setDeleteButtonToolTip(options.deleteToolTip);
+    card->setOpenButtonVisible(options.showOpenButton);
+    card->setOpenButtonEnabled(options.enableOpenButton);
+    if (!options.openToolTip.isEmpty())
+        card->setOpenButtonToolTip(options.openToolTip);
 
     // 放进网格
     auto* grid = qobject_cast<QGridLayout*>(ui->gridLayout);

--- a/SchemeGalleryWidget.h
+++ b/SchemeGalleryWidget.h
@@ -20,9 +20,12 @@ public:
         bool enableAddButton = true;
         bool showDeleteButton = true;
         bool enableDeleteButton = true;
+        bool showOpenButton = false;
+        bool enableOpenButton = true;
         QString hintText;
         QString addToolTip;
         QString deleteToolTip;
+        QString openToolTip;
     };
 
     void clearSchemes();


### PR DESCRIPTION
## Summary
- show the active project as the root tree node and keep scheme/model names unique across edits and imports
- refresh scheme creation, import, and gallery workflows so double-click adds schemes, a dedicated button opens directories, and icons use the updated resource path
- restyle the scheme detail pane with a cleaner information card and model list for easier management

## Testing
- not run (Qt project without automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68ccf6c22170832d89e9f29810801925