### PR TITLE
Refine navigation and update UI layout

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -32,7 +32,6 @@ public:
     ~MainWindow();
 
 private slots:
-    void on_showPlanPushButton_clicked();
     void handleTreeSelectionChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
     void onTreeItemChanged(QTreeWidgetItem* item, int column);
     void onTreeContextMenuRequested(const QPoint& pos);
@@ -80,7 +79,8 @@ private:
     };
 
     enum TreeItemType {
-        ProjectItem = 0,
+        LibraryItem = 0,
+        ProjectItem,
         SchemeItem,
         ModelItem
     };
@@ -174,6 +174,7 @@ private:
     QVector<SchemeRecord> m_schemes;
     QHash<QString, QTreeWidgetItem*> m_schemeItems;
     QHash<QString, QTreeWidgetItem*> m_modelItems;
+    QTreeWidgetItem* m_libraryRootItem = nullptr;
     QTreeWidgetItem* m_projectRootItem = nullptr;
     QString m_activeSchemeId;
     QString m_activeModelId;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -31,118 +31,6 @@
      <number>12</number>
     </property>
     <item>
-     <widget class="QWidget" name="headerWidget" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <layout class="QHBoxLayout" name="headerLayout">
-       <property name="spacing">
-        <number>10</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QFrame" name="libraryCard">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
-         </property>
-         <layout class="QHBoxLayout" name="libraryCardLayout">
-          <property name="spacing">
-           <number>12</number>
-          </property>
-          <property name="leftMargin">
-           <number>16</number>
-          </property>
-          <property name="topMargin">
-           <number>12</number>
-          </property>
-          <property name="rightMargin">
-           <number>16</number>
-          </property>
-          <property name="bottomMargin">
-           <number>12</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="spacing">
-             <number>6</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="showPlanPushButton">
-              <property name="toolTip">
-               <string>查看所有方案</string>
-              </property>
-              <property name="text">
-               <string>方案库</string>
-              </property>
-              <property name="icon">
-               <iconset resource="resources.qrc">
-                <normaloff>:/icons/icons/gallery.svg</normaloff>:/icons/icons/gallery.svg</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
      <widget class="QSplitter" name="mainSplitter">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
@@ -173,7 +61,7 @@
            <string notr="true">font-size:15px;font-weight:600;</string>
           </property>
           <property name="text">
-           <string>方案与模型</string>
+           <string>导航</string>
           </property>
          </widget>
         </item>
@@ -193,7 +81,7 @@
           </property>
           <column>
            <property name="text">
-            <string>方案 / 模型</string>
+            <string>方案库</string>
            </property>
           </column>
          </widget>
@@ -432,14 +320,14 @@
               </widget>
              </item>
              <item>
-              <widget class="QFrame" name="vtkFrame">
-               <property name="frameShape">
-                <enum>QFrame::StyledPanel</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Raised</enum>
-               </property>
-               <layout class="QVBoxLayout" name="vtkFrameLayout">
+             <widget class="QFrame" name="vtkFrame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="vtkFrameLayout">
                 <property name="spacing">
                  <number>0</number>
                 </property>
@@ -464,47 +352,47 @@
                    </size>
                   </property>
                  </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="logTitle">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font-size:15px;font-weight:600;</string>
+              </property>
+              <property name="text">
+               <string>运行日志</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPlainTextEdit" name="logTextEdit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="maximumBlockCount">
+               <number>1000</number>
+              </property>
+              <property name="placeholderText">
+               <string>日志输出...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="logTitle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">font-size:15px;font-weight:600;</string>
-           </property>
-           <property name="text">
-            <string>运行日志</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPlainTextEdit" name="logTextEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-           <property name="maximumBlockCount">
-            <number>1000</number>
-           </property>
-           <property name="placeholderText">
-            <string>日志输出...</string>
-           </property>
           </widget>
          </item>
         </layout>

--- a/icons/app_logo.svg
+++ b/icons/app_logo.svg
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="32" cy="32" r="28" fill="#2563eb"/>
-  <path d="M22 18h20v6H28v8h12v6H28v14h-6V18z" fill="#f8fafc"/>
-  <path d="M32 6a26 26 0 1 1-26 26A26 26 0 0 1 32 6zm0 4a22 22 0 1 0 22 22A22 22 0 0 0 32 10z" fill="#1d4ed8" opacity="0.35"/>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+    <linearGradient id="waveGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.95"/>
+      <stop offset="100%" stop-color="#e0f2fe" stop-opacity="0.75"/>
+    </linearGradient>
+    <linearGradient id="borderGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#1e40af" stop-opacity="0.9"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="80" height="80" rx="22" fill="url(#bgGradient)"/>
+  <path d="M20 56c10-18 24-20 34-10s20 12 22 8" fill="none" stroke="url(#waveGradient)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" opacity="0.95"/>
+  <path d="M24 34c6 8 16 12 26 6s18-6 22 4" fill="none" stroke="#bfdbfe" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>
+  <circle cx="64" cy="30" r="6" fill="#f8fafc" opacity="0.95"/>
+  <circle cx="64" cy="30" r="4" fill="#38bdf8"/>
+  <path d="M30 74c8-8 18-12 28-8" fill="none" stroke="#0ea5e9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.8"/>
+  <rect x="8" y="8" width="80" height="80" rx="22" fill="none" stroke="url(#borderGradient)" stroke-width="2" opacity="0.8"/>
 </svg>

--- a/main.cpp
+++ b/main.cpp
@@ -2,10 +2,15 @@
 #include "mainwindow.h"
 
 #include <QApplication>
+#include <QFont>
 
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+
+    QFont appFont(QStringLiteral("Microsoft YaHei"));
+    appFont.setStyleHint(QFont::SansSerif, QFont::PreferQuality);
+    a.setFont(appFont);
 
     MainWindow w;
     w.show();


### PR DESCRIPTION
## Summary
- replace the standalone scheme library button with a navigation tree entry and handle its selection/context actions
- keep the VTK view and log pane aligned by relocating the log widgets inside the viewer panel and removing the header card
- simplify the model settings panel, set Microsoft YaHei as the default font, and provide a refreshed application icon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd081ecd54832da7f384ac68836f30