### PR TITLE
Improve layout branding and log panel usability

### DIFF
--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -31,6 +31,143 @@
      <number>12</number>
     </property>
     <item>
+     <widget class="QFrame" name="headerFrame">
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QFrame#headerFrame{background:#f8fafc;border-radius:12px;padding:8px 16px;}</string>
+      </property>
+      <layout class="QHBoxLayout" name="headerLayout">
+       <property name="spacing">
+        <number>12</number>
+       </property>
+       <property name="leftMargin">
+        <number>12</number>
+       </property>
+       <property name="topMargin">
+        <number>12</number>
+       </property>
+       <property name="rightMargin">
+        <number>12</number>
+       </property>
+       <property name="bottomMargin">
+        <number>12</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="appLogoLabel">
+         <property name="minimumSize">
+          <size>
+           <width>48</width>
+           <height>48</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>64</width>
+           <height>64</height>
+          </size>
+         </property>
+         <property name="pixmap">
+          <pixmap resource="resources.qrc">:/icons/icons/app_logo.svg</pixmap>
+         </property>
+         <property name="scaledContents">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="appTitleLabel">
+         <property name="styleSheet">
+          <string notr="true">font-size:22px;font-weight:700;color:#0f172a;</string>
+         </property>
+         <property name="text">
+          <string>柔性仿真软件</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="headerSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QFrame" name="projectBadge">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QFrame#projectBadge{background:#e0f2fe;border-radius:12px;padding:6px 12px;}QLabel#projectTitleLabel{font-size:14px;font-weight:600;color:#0f172a;}</string>
+         </property>
+         <layout class="QHBoxLayout" name="projectBadgeLayout">
+          <property name="spacing">
+           <number>8</number>
+          </property>
+          <property name="leftMargin">
+           <number>10</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>10</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="projectLogoLabel">
+            <property name="minimumSize">
+             <size>
+              <width>28</width>
+              <height>28</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>32</width>
+              <height>32</height>
+             </size>
+            </property>
+            <property name="pixmap">
+             <pixmap resource="resources.qrc">:/icons/icons/project_logo.svg</pixmap>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="projectTitleLabel">
+            <property name="text">
+             <string>未打开工程</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
      <widget class="QSplitter" name="mainSplitter">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
@@ -303,33 +440,21 @@
              <property name="bottomMargin">
               <number>0</number>
              </property>
-             <item>
-              <widget class="QLabel" name="vtkTitle">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">font-size:15px;font-weight:600;</string>
-               </property>
-               <property name="text">
-                <string>模型预览</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-             <widget class="QFrame" name="vtkFrame">
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
+            <item>
+             <widget class="QSplitter" name="visualizationSplitter">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-              <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
+              <property name="childrenCollapsible">
+               <bool>false</bool>
               </property>
-              <layout class="QVBoxLayout" name="vtkFrameLayout">
+              <widget class="QFrame" name="vtkContainer">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <layout class="QVBoxLayout" name="vtkContainerLayout">
                 <property name="spacing">
-                 <number>0</number>
+                 <number>8</number>
                 </property>
                 <property name="leftMargin">
                  <number>0</number>
@@ -344,51 +469,111 @@
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QVTKOpenGLNativeWidget" name="vtkWidget" native="true">
-                  <property name="minimumSize">
-                   <size>
-                    <width>400</width>
-                    <height>420</height>
-                   </size>
+                 <widget class="QLabel" name="vtkTitle">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>模型预览</string>
                   </property>
                  </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="logTitle">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font-size:15px;font-weight:600;</string>
-              </property>
-              <property name="text">
-               <string>运行日志</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPlainTextEdit" name="logTextEdit">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>1</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-              <property name="maximumBlockCount">
-               <number>1000</number>
-              </property>
-              <property name="placeholderText">
-               <string>日志输出...</string>
-              </property>
+                </item>
+                <item>
+                 <widget class="QFrame" name="vtkFrame">
+                  <property name="frameShape">
+                   <enum>QFrame::StyledPanel</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Raised</enum>
+                  </property>
+                  <layout class="QVBoxLayout" name="vtkFrameLayout">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QVTKOpenGLNativeWidget" name="vtkWidget" native="true">
+                     <property name="minimumSize">
+                      <size>
+                       <width>400</width>
+                       <height>420</height>
+                      </size>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+              <widget class="QFrame" name="logPanel">
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <layout class="QVBoxLayout" name="logPanelLayout">
+                <property name="spacing">
+                 <number>8</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="logTitle">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>运行日志</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPlainTextEdit" name="logTextEdit">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>1</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="readOnly">
+                   <bool>true</bool>
+                  </property>
+                  <property name="maximumBlockCount">
+                   <number>1000</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string>日志输出...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
              </widget>
             </item>
            </layout>

--- a/icons/project_logo.svg
+++ b/icons/project_logo.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="projectGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#047857"/>
+      <stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#bbf7d0"/>
+      <stop offset="100%" stop-color="#86efac"/>
+    </linearGradient>
+    <linearGradient id="shadowGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f766e" stop-opacity="0.45"/>
+      <stop offset="100%" stop-color="#0f766e" stop-opacity="0.05"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="76" height="76" rx="20" fill="url(#projectGradient)"/>
+  <path d="M24 66h48v6H24z" fill="#0f172a" opacity="0.2"/>
+  <g transform="translate(20 22)">
+    <path d="M12 0h20l12 12v32a6 6 0 0 1-6 6H12a6 6 0 0 1-6-6V6a6 6 0 0 1 6-6z" fill="url(#accentGradient)"/>
+    <path d="M32 0v12h12z" fill="#ecfdf5"/>
+    <path d="M12 18h16v4H12z" fill="#047857" opacity="0.85"/>
+    <path d="M12 28h24v4H12z" fill="#0f766e" opacity="0.9"/>
+    <path d="M12 38h18v4H12z" fill="#047857" opacity="0.85"/>
+  </g>
+  <path d="M24 24l32 32" stroke="url(#shadowGradient)" stroke-width="6" stroke-linecap="round" opacity="0.4"/>
+  <rect x="10" y="10" width="76" height="76" rx="20" fill="none" stroke="#0f766e" stroke-opacity="0.5" stroke-width="2"/>
+</svg>

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/icons">
         <file>icons/app_logo.svg</file>
+        <file>icons/project_logo.svg</file>
         <file>icons/add.svg</file>
         <file>icons/model_add.svg</file>
         <file>icons/folder.svg</file>


### PR DESCRIPTION
## Summary
- add a branded header with the application logo and a distinct project badge
- introduce a vertical splitter between the VTK preview and log panel so users can resize the areas
- refresh section title styling for better continuity and add a dedicated project icon asset

## Testing
- qmake FlexSimulate.pro *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0d4c6ddc832d8b63274d1e51970d