### PR TITLE
Remove ability to add library schemes to projects

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -38,7 +38,6 @@ private slots:
     void onTreeItemsReordered();
     void onExternalDrop(const QList<QUrl>& urls, QTreeWidgetItem* target);
     void onGalleryOpenRequested(const QString& id);
-    void onGalleryAddRequested(const QString& id);
     void onGalleryDeleteRequested(const QString& id);
     void onGalleryDetailsRequested(const QString& id);
     void deleteCurrentTreeItem();

--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -27,9 +27,9 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
         "QLabel#imageLabel{background:#f6f7fb;border-radius:12px;"
         "border:1px dashed #d0d6e5;color:#8a93a6;font-size:13px;"
         "padding:12px;line-height:20px;}"
-        "QToolButton#addButton, QToolButton#openButton{border:none;border-radius:12px;padding:4px;"
+        "QToolButton#openButton{border:none;border-radius:12px;padding:4px;"
         "color:#0b57d0;background:rgba(11,87,208,0.08);}"
-        "QToolButton#addButton:hover, QToolButton#openButton:hover{background:rgba(11,87,208,0.16);}"
+        "QToolButton#openButton:hover{background:rgba(11,87,208,0.16);}"
         "QToolButton#deleteButton{border:none;border-radius:12px;"
         "padding:4px;color:#d93025;"
         "background:rgba(217,48,37,0.08);}"
@@ -68,16 +68,6 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     m_openBtn->setVisible(false);
     header->addWidget(m_openBtn, 0, Qt::AlignRight);
 
-    m_addBtn = new QToolButton(this);
-    m_addBtn->setObjectName("addButton");
-    m_addBtn->setToolTip(tr("添加到当前工程"));
-    m_addBtn->setIcon(QIcon(QStringLiteral(":/icons/icons/add.svg")));
-    m_addBtn->setIconSize(QSize(16, 16));
-    m_addBtn->setAutoRaise(false);
-    m_addBtn->setCursor(Qt::ArrowCursor);
-    m_addBtn->setVisible(false);
-    header->addWidget(m_addBtn, 0, Qt::AlignRight);
-
     m_deleteBtn = new QToolButton(this);
     m_deleteBtn->setObjectName("deleteButton");
     m_deleteBtn->setToolTip(tr("删除此方案"));
@@ -105,9 +95,6 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     m_hintLabel->setText(tr("点击卡片以查看详情"));
     lay->addWidget(m_hintLabel);
 
-    connect(m_addBtn, &QToolButton::clicked, this, [this]() {
-        emit addRequested(m_id);
-    });
     connect(m_deleteBtn, &QToolButton::clicked, this, [this]() {
         emit deleteRequested(m_id);
     });
@@ -132,18 +119,6 @@ void SchemeCardWidget::setHintText(const QString& text)
         m_hintLabel->setText(text);
 }
 
-void SchemeCardWidget::setAddButtonVisible(bool visible)
-{
-    if (m_addBtn)
-        m_addBtn->setVisible(visible);
-}
-
-void SchemeCardWidget::setAddButtonEnabled(bool enabled)
-{
-    if (m_addBtn)
-        m_addBtn->setEnabled(enabled);
-}
-
 void SchemeCardWidget::setDeleteButtonVisible(bool visible)
 {
     if (m_deleteBtn)
@@ -154,12 +129,6 @@ void SchemeCardWidget::setDeleteButtonEnabled(bool enabled)
 {
     if (m_deleteBtn)
         m_deleteBtn->setEnabled(enabled);
-}
-
-void SchemeCardWidget::setAddButtonToolTip(const QString& text)
-{
-    if (m_addBtn)
-        m_addBtn->setToolTip(text);
 }
 
 void SchemeCardWidget::setDeleteButtonToolTip(const QString& text)
@@ -193,10 +162,9 @@ void SchemeCardWidget::mousePressEvent(QMouseEvent* ev)
 
 void SchemeCardWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-    const bool onAdd = isPointInsideButton(m_addBtn, ev->pos());
     const bool onDelete = isPointInsideButton(m_deleteBtn, ev->pos());
     const bool onOpen = isPointInsideButton(m_openBtn, ev->pos());
-    if (!onAdd && !onDelete && !onOpen)
+    if (!onDelete && !onOpen)
         emit detailsRequested(m_id);
     QFrame::mouseDoubleClickEvent(ev);
 }

--- a/SchemeCardWidget.h
+++ b/SchemeCardWidget.h
@@ -15,11 +15,8 @@ public:
 
     void setThumbnail(const QPixmap& pm);
     void setHintText(const QString& text);
-    void setAddButtonVisible(bool visible);
-    void setAddButtonEnabled(bool enabled);
     void setDeleteButtonVisible(bool visible);
     void setDeleteButtonEnabled(bool enabled);
-    void setAddButtonToolTip(const QString& text);
     void setDeleteButtonToolTip(const QString& text);
     void setOpenButtonVisible(bool visible);
     void setOpenButtonEnabled(bool enabled);
@@ -28,7 +25,6 @@ public:
 
 signals:
     void openRequested(const QString& id);
-    void addRequested(const QString& id);
     void deleteRequested(const QString& id);
     void detailsRequested(const QString& id);
 
@@ -44,7 +40,6 @@ private:
     QString m_id;
     QLabel* m_imageLabel;
     QLabel* m_titleLabel;
-    QToolButton* m_addBtn;
     QToolButton* m_deleteBtn;
     QToolButton* m_openBtn;
     QLabel* m_hintLabel;

--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -59,10 +59,6 @@ void SchemeGalleryWidget::addScheme(const QString& id,
     card->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     if (!options.hintText.isEmpty())
         card->setHintText(options.hintText);
-    card->setAddButtonVisible(options.showAddButton);
-    card->setAddButtonEnabled(options.enableAddButton);
-    if (!options.addToolTip.isEmpty())
-        card->setAddButtonToolTip(options.addToolTip);
     card->setDeleteButtonVisible(options.showDeleteButton);
     card->setDeleteButtonEnabled(options.enableDeleteButton);
     if (!options.deleteToolTip.isEmpty())
@@ -80,9 +76,6 @@ void SchemeGalleryWidget::addScheme(const QString& id,
     // 打开设置
     connect(card, &SchemeCardWidget::openRequested,
             this, &SchemeGalleryWidget::schemeOpenRequested);
-
-    connect(card, &SchemeCardWidget::addRequested,
-            this, &SchemeGalleryWidget::schemeAddRequested);
 
     connect(card, &SchemeCardWidget::detailsRequested,
             this, &SchemeGalleryWidget::schemeDetailsRequested);

--- a/SchemeGalleryWidget.h
+++ b/SchemeGalleryWidget.h
@@ -16,14 +16,11 @@ public:
     ~SchemeGalleryWidget();
 
     struct CardOptions {
-        bool showAddButton = false;
-        bool enableAddButton = true;
         bool showDeleteButton = true;
         bool enableDeleteButton = true;
         bool showOpenButton = false;
         bool enableOpenButton = true;
         QString hintText;
-        QString addToolTip;
         QString deleteToolTip;
         QString openToolTip;
     };
@@ -37,7 +34,6 @@ public:
 
 signals:
     void schemeOpenRequested(const QString& id);
-    void schemeAddRequested(const QString& id);
     void schemeDeleteRequested(const QString& id);
     void schemeDetailsRequested(const QString& id);
     void createSchemeRequested();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -242,8 +242,6 @@ void MainWindow::setupConnections()
 
     connect(m_galleryWidget, &SchemeGalleryWidget::schemeOpenRequested,
             this, &MainWindow::onGalleryOpenRequested);
-    connect(m_galleryWidget, &SchemeGalleryWidget::schemeAddRequested,
-            this, &MainWindow::onGalleryAddRequested);
     connect(m_galleryWidget, &SchemeGalleryWidget::schemeDeleteRequested,
             this, &MainWindow::onGalleryDeleteRequested);
     connect(m_galleryWidget, &SchemeGalleryWidget::schemeDetailsRequested,
@@ -1094,73 +1092,6 @@ void MainWindow::onGalleryOpenRequested(const QString& id)
     }
 }
 
-void MainWindow::onGalleryAddRequested(const QString& id)
-{
-    const SchemeLibraryEntry* entry = libraryEntryById(id);
-    if (!entry)
-        return;
-
-    if (!hasActiveProject())
-    {
-        QMessageBox::information(this, tr("添加方案"), tr("请先新建或打开工程。"));
-        return;
-    }
-
-    SchemeRecord* existing = schemeByLibraryId(entry->id);
-    if (existing)
-    {
-        ui->stackedWidget->setCurrentWidget(ui->MainPage);
-        selectTreeItem(existing->id, QString());
-        return;
-    }
-
-    if (entry->directory.isEmpty() || !QDir(entry->directory).exists())
-    {
-        QMessageBox::warning(this, tr("添加方案"), tr("方案库目录不存在或不可访问。"));
-        return;
-    }
-
-    const QString entryName = entry->name.isEmpty() ? tr("未命名方案") : entry->name;
-
-    QString targetDir = makeUniqueWorkspaceSubdir(entryName);
-    if (targetDir.isEmpty())
-    {
-        QMessageBox::warning(this, tr("添加方案"), tr("无法创建方案工作目录。"));
-        return;
-    }
-
-    if (!ensureDirectoryExists(targetDir))
-    {
-        QMessageBox::warning(this, tr("添加方案"),
-                             tr("无法创建方案工作目录。"));
-        return;
-    }
-
-    const QString schemeId = createScheme(entryName, targetDir);
-    if (schemeId.isEmpty())
-    {
-        QDir(targetDir).removeRecursively();
-        QMessageBox::warning(this, tr("添加方案"), tr("无法在工程中创建方案。"));
-        return;
-    }
-
-    SchemeRecord* scheme = schemeById(schemeId);
-    if (!scheme)
-        return;
-
-    scheme->libraryId = entry->id;
-    if (!entry->thumbnailPath.isEmpty())
-        scheme->thumbnailPath = QDir::cleanPath(entry->thumbnailPath);
-    else
-        scheme->thumbnailPath.clear();
-
-    persistSchemes();
-    refreshNavigation(schemeId);
-    appendLogMessage(tr("已将方案库 %1 加入工程").arg(entryName));
-    ui->stackedWidget->setCurrentWidget(ui->MainPage);
-    selectTreeItem(schemeId, QString());
-}
-
 void MainWindow::onGalleryDeleteRequested(const QString& id)
 {
     if (SchemeLibraryEntry* entry = libraryEntryById(id))
@@ -1341,8 +1272,6 @@ void MainWindow::updateGallery()
         return;
 
     m_galleryWidget->clearSchemes();
-    const bool hasProject = hasActiveProject();
-
     for (const SchemeLibraryEntry& entry : m_librarySchemes)
     {
         QPixmap thumb = loadLibraryThumbnail(entry);
@@ -1350,10 +1279,6 @@ void MainWindow::updateGallery()
             thumb = makeSchemePlaceholder(entry.name);
 
         SchemeGalleryWidget::CardOptions options;
-        options.showAddButton = true;
-        options.enableAddButton = hasProject;
-        options.addToolTip = hasProject ? tr("添加到当前工程")
-                                        : tr("请先新建或打开工程。");
         options.showDeleteButton = entry.deletable;
         options.enableDeleteButton = entry.deletable;
         options.deleteToolTip = entry.deletable
@@ -1388,7 +1313,6 @@ void MainWindow::updateGallery()
         }
 
         SchemeGalleryWidget::CardOptions options;
-        options.showAddButton = false;
         options.showOpenButton = true;
         options.openToolTip = tr("查看方案详情");
         options.hintText = linkedEntry ? tr("双击查看方案库详情")
@@ -1944,7 +1868,7 @@ void MainWindow::showLibrarySchemeDetail(const QString& entryId,
                 if (m_schemes.isEmpty())
                 {
                     QMessageBox::information(this, tr("添加到工程"),
-                                             tr("当前工程中没有方案，请先从方案库添加方案。"));
+                                             tr("当前工程中没有方案，无法导入模型。"));
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- remove the scheme gallery "add to project" controls and signals so cards only allow opening, details or deletion
- stop configuring add-button options in the gallery and clarify the message shown when no schemes exist during model import

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0c7068e10832da5b2fbde6c83c8cb