### PR TITLE
Refine panel styling

### DIFF
--- a/JsonPageBuilder.cpp
+++ b/JsonPageBuilder.cpp
@@ -41,9 +41,6 @@ JsonPageBuilder::JsonPageBuilder(const QString& jsonPath, QWidget* parent)
     : QWidget(parent)
     , m_jsonPath(QFileInfo(jsonPath).absoluteFilePath())
 {
-    setWindowTitle(("广汽APP-Demo"));
-    setMinimumWidth(500);
-
     QFileInfo info(m_jsonPath);
     if (info.exists())
     {
@@ -65,51 +62,61 @@ JsonPageBuilder::JsonPageBuilder(const QString& jsonPath, QWidget* parent)
 void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
 {
     auto* mainLayout = new QVBoxLayout(this);
+    mainLayout->setSpacing(12);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
 
     for (int i = 0; i < sections.size(); ++i)
     {
         const QJsonObject sec = sections.at(i).toObject();
         const QString title = sec.value("title").toString();
 
+        // 标题按钮
         auto* titleBtn = new QPushButton(title, this);
         titleBtn->setMinimumHeight(40);
         titleBtn->setStyleSheet(kBtnQss);
-
         mainLayout->addWidget(titleBtn);
         m_titleButtons.push_back(titleBtn);
+
+        // 本分组的网格布局：左列标签，右列输入框
+        auto* grid = new QGridLayout();
+        grid->setHorizontalSpacing(12);
+        grid->setVerticalSpacing(8);
+        grid->setContentsMargins(6, 0, 6, 6);
+        grid->setColumnStretch(0, 0); // label 列不拉伸
+        grid->setColumnStretch(1, 1); // edit 列自适应拉伸
 
         QVector<QLabel*> nameLabels;
         QVector<QLineEdit*> edits;
 
         const QJsonArray dataList = sec.value("data").toArray();
-        for (int j = 0; j < dataList.size(); ++j) {
-            const QJsonObject item = dataList.at(j).toObject();
+        for (int row = 0; row < dataList.size(); ++row) {
+            const QJsonObject item = dataList.at(row).toObject();
             const QString cnName = item.value("cn_name").toString();
             const QJsonValue val = item.value("value");
 
-            auto* h = new QHBoxLayout();
-            auto* lab = new QLabel(cnName + ("："), this);
-            lab->setMinimumWidth(80);
-            lab->setMinimumHeight(40);
+            auto* lab = new QLabel(cnName + QString("："), this);
+            lab->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 
             auto* edit = new QLineEdit(this);
-            // 将 JSON 值回显为字符串
+            // JSON 值回显为字符串
             if (val.isDouble()) {
                 edit->setText(QString::number(val.toDouble(), 'g', 15));
             } else if (val.isString()) {
                 edit->setText(val.toString());
             } else if (val.isBool()) {
-                edit->setText(val.toBool() ? "1" : "0");
-            } else if (val.isNull() || val.isUndefined()) {
-                edit->setText("");
-            } else {
-                // 其他类型（对象/数组）不在本场景中，转成字符串
-                edit->setText(QString::fromUtf8(QJsonDocument(val.toObject()).toJson(QJsonDocument::Compact)));
+                edit->setText(val.toBool() ? QString("1") : QString("0"));
+            } else if (val.isArray()) {
+                edit->setText(QString::fromUtf8(QJsonDocument(val.toArray())
+                                                .toJson(QJsonDocument::Compact)));
+            } else if (val.isObject()) {
+                edit->setText(QString::fromUtf8(QJsonDocument(val.toObject())
+                                                .toJson(QJsonDocument::Compact)));
+            } else { // null / undefined
+                edit->setText(QString());
             }
 
-            h->addWidget(lab, 1);
-            h->addWidget(edit, 2);
-            mainLayout->addLayout(h);
+            grid->addWidget(lab,  row, 0);
+            grid->addWidget(edit, row, 1);
 
             nameLabels.push_back(lab);
             edits.push_back(edit);
@@ -117,9 +124,12 @@ void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
 
         m_labelNameWidgets.push_back(nameLabels);
         m_labelDataWidgets.push_back(edits);
+
+        mainLayout->addLayout(grid);
     }
 
-    m_calculateButton = new QPushButton(("计算"), this);
+    // 计算按钮
+    m_calculateButton = new QPushButton(QString("计算"), this);
     m_calculateButton->setMinimumHeight(40);
     connect(m_calculateButton, &QPushButton::clicked,
             this, &JsonPageBuilder::onCalculateButtonClicked);
@@ -127,8 +137,8 @@ void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
     mainLayout->addWidget(m_calculateButton);
     mainLayout->addStretch(1);
     setLayout(mainLayout);
-    resize(400, 600);
 }
+
 
 bool JsonPageBuilder::loadJson(const QString& path, QJsonArray& outSections)
 {

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -41,7 +41,7 @@
        </property>
        <layout class="QVBoxLayout" name="navigationLayout">
         <property name="spacing">
-         <number>6</number>
+         <number>0</number>
         </property>
         <property name="leftMargin">
          <number>0</number>
@@ -57,9 +57,6 @@
         </property>
         <item>
          <widget class="QLabel" name="navigationTitle">
-          <property name="styleSheet">
-           <string notr="true">font-size:15px;font-weight:600;</string>
-          </property>
           <property name="text">
            <string>导航</string>
           </property>
@@ -203,7 +200,7 @@
            <widget class="QWidget" name="detailPanel" native="true">
             <layout class="QVBoxLayout" name="detailPanelLayout">
              <property name="spacing">
-              <number>8</number>
+              <number>0</number>
              </property>
              <property name="leftMargin">
               <number>0</number>
@@ -219,9 +216,6 @@
              </property>
              <item>
               <widget class="QLabel" name="detailTitle">
-               <property name="styleSheet">
-                <string notr="true">font-size:15px;font-weight:600;</string>
-               </property>
                <property name="text">
                 <string>参数设置</string>
                </property>
@@ -317,7 +311,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="vtkContainerLayout">
                  <property name="spacing">
-                  <number>8</number>
+                  <number>0</number>
                  </property>
                  <property name="leftMargin">
                   <number>0</number>
@@ -347,10 +341,10 @@
                  <item>
                   <widget class="QFrame" name="vtkFrame">
                    <property name="frameShape">
-                    <enum>QFrame::StyledPanel</enum>
+                    <enum>QFrame::NoFrame</enum>
                    </property>
                    <property name="frameShadow">
-                    <enum>QFrame::Raised</enum>
+                    <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QVBoxLayout" name="vtkFrameLayout">
                     <property name="spacing">
@@ -389,7 +383,7 @@
                 </property>
                 <layout class="QVBoxLayout" name="logPanelLayout">
                  <property name="spacing">
-                  <number>8</number>
+                  <number>0</number>
                  </property>
                  <property name="leftMargin">
                   <number>0</number>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -50,6 +50,7 @@
 #include <QTreeWidgetItem>
 #include <QUuid>
 #include <QVBoxLayout>
+#include <QWidget>
 #include <algorithm>
 
 #include <QVTKOpenGLNativeWidget.h>
@@ -165,24 +166,72 @@ MainWindow::~MainWindow()
 
 void MainWindow::setupUiHelpers()
 {
+    if (auto* central = ui->centralwidget)
+    {
+        central->setAttribute(Qt::WA_StyledBackground, true);
+        central->setStyleSheet(QStringLiteral("QWidget#centralwidget{background:#f1f5f9;}"));
+    }
+
     m_galleryWidget = new SchemeGalleryWidget(this);
     ui->planPageLayout->addWidget(m_galleryWidget);
 
     auto* detailLayout = new QVBoxLayout(ui->settingWidget);
-    detailLayout->setContentsMargins(12, 12, 12, 12);
-    detailLayout->setSpacing(12);
+    detailLayout->setContentsMargins(20, 20, 20, 20);
+    detailLayout->setSpacing(16);
 
-    const QString sectionTitleStyle = QStringLiteral(
-        "font-size:15px;font-weight:600;color:#0f172a;"
-        "background:#e2e8f0;border-radius:8px;padding:6px 12px;");
-    const auto applySectionStyle = [&](QLabel* label) {
-        if (label)
-            label->setStyleSheet(sectionTitleStyle);
+    const auto applyPanelCard = [](QWidget* panel, QLabel* title, const QString& extraStyles = QString()) {
+        if (!panel || !title)
+            return;
+
+        panel->setAttribute(Qt::WA_StyledBackground, true);
+        const QString panelSelector = panel->objectName().isEmpty()
+                                          ? QStringLiteral("%1").arg(QString::fromLatin1(panel->metaObject()->className()))
+                                          : QStringLiteral("%1#%2").arg(QString::fromLatin1(panel->metaObject()->className()), panel->objectName());
+        const QString titleSelector = title->objectName().isEmpty()
+                                          ? QStringLiteral("QLabel")
+                                          : QStringLiteral("QLabel#%1").arg(title->objectName());
+        QString style = QStringLiteral(
+            "%1{background:#ffffff;border:1px solid #d6e1f2;border-radius:14px;}"
+            "%2{font-size:15px;font-weight:600;color:#0f172a;padding:12px 16px;"
+            "background:#f8fafc;border-top-left-radius:14px;border-top-right-radius:14px;"
+            "border-bottom:1px solid #e2e8f0;}"
+            "%3"
+        ).arg(panelSelector, titleSelector, extraStyles);
+        panel->setStyleSheet(style);
     };
-    applySectionStyle(ui->navigationTitle);
-    applySectionStyle(ui->detailTitle);
-    applySectionStyle(ui->vtkTitle);
-    applySectionStyle(ui->logTitle);
+
+    applyPanelCard(ui->navigationFrame, ui->navigationTitle,
+                   QStringLiteral(
+                       "QTreeWidget{border:none;background:transparent;padding:8px 12px;}"
+                       "QTreeWidget::item{padding:6px 4px;}"
+                       "QTreeWidget::item:hover{background:#f1f5f9;}"
+                       "QTreeWidget::item:selected{background:#e2e8f0;color:#0f172a;}"
+                       "QHeaderView::section{background:transparent;border:none;padding:4px 0;font-weight:600;color:#334155;}"
+                   ));
+
+    applyPanelCard(ui->detailPanel, ui->detailTitle,
+                   QStringLiteral(
+                       "QScrollArea{border:none;background:transparent;}"
+                       "QWidget#scrollAreaWidgetContents{background:transparent;}"
+                   ));
+
+    applyPanelCard(ui->vtkPanel, ui->vtkTitle,
+                   QStringLiteral(
+                       "QFrame#vtkFrame{border:none;background:transparent;border-bottom-left-radius:14px;border-bottom-right-radius:14px;}"
+                       "QVTKOpenGLNativeWidget{border:none;border-bottom-left-radius:14px;border-bottom-right-radius:14px;}"
+                   ));
+
+    applyPanelCard(ui->logPanel, ui->logTitle);
+
+    const QString splitterStyle = QStringLiteral(
+        "QSplitter::handle{background:#cbd5f5;}"
+        "QSplitter::handle:horizontal{width:8px;margin:0 4px;border-radius:4px;}"
+        "QSplitter::handle:vertical{height:8px;margin:4px 0;border-radius:4px;}"
+    );
+    ui->mainSplitter->setStyleSheet(splitterStyle);
+    ui->contentSplitter->setStyleSheet(splitterStyle);
+    if (ui->visualizationSplitter)
+        ui->visualizationSplitter->setStyleSheet(splitterStyle);
 
     ui->treeModels->header()->setStretchLastSection(true);
     ui->treeModels->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -202,7 +251,9 @@ void MainWindow::setupUiHelpers()
     }
 
     ui->logTextEdit->setStyleSheet(
-        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border-radius:6px;padding:6px;}"
+        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border:none;"
+        "border-bottom-left-radius:14px;border-bottom-right-radius:14px;padding:12px;"
+        "font-family:\"JetBrains Mono\", \"Source Code Pro\", monospace;}"
     );
 
     setVisualizationVisible(false);


### PR DESCRIPTION
## Summary
- tighten layout spacing and frame configuration so navigation, details, preview, and log panels share integrated headers with their content
- apply consistent card-style palettes, background, and splitter visuals for the main workspace and update the log console styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0f32ca7b8832da3c2b4a482a4eade