### PR TITLE
Refine UI styling for main workspace

### DIFF
--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -41,19 +41,19 @@
        </property>
        <layout class="QVBoxLayout" name="navigationLayout">
         <property name="spacing">
-         <number>6</number>
+         <number>12</number>
         </property>
         <property name="leftMargin">
-         <number>0</number>
+         <number>16</number>
         </property>
         <property name="topMargin">
-         <number>0</number>
+         <number>16</number>
         </property>
         <property name="rightMargin">
-         <number>0</number>
+         <number>16</number>
         </property>
         <property name="bottomMargin">
-         <number>0</number>
+         <number>16</number>
         </property>
         <item>
          <widget class="QLabel" name="navigationTitle">
@@ -203,19 +203,19 @@
            <widget class="QWidget" name="detailPanel" native="true">
             <layout class="QVBoxLayout" name="detailPanelLayout">
              <property name="spacing">
-              <number>8</number>
+              <number>12</number>
              </property>
              <property name="leftMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="topMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="bottomMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <item>
               <widget class="QLabel" name="detailTitle">
@@ -289,19 +289,19 @@
            <widget class="QWidget" name="vtkPanel" native="true">
             <layout class="QVBoxLayout" name="vtkPanelLayout">
              <property name="spacing">
-              <number>8</number>
+              <number>12</number>
              </property>
              <property name="leftMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="topMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <property name="bottomMargin">
-              <number>0</number>
+              <number>16</number>
              </property>
              <item>
               <widget class="QSplitter" name="visualizationSplitter">
@@ -347,10 +347,10 @@
                  <item>
                   <widget class="QFrame" name="vtkFrame">
                    <property name="frameShape">
-                    <enum>QFrame::StyledPanel</enum>
+                    <enum>QFrame::NoFrame</enum>
                    </property>
                    <property name="frameShadow">
-                    <enum>QFrame::Raised</enum>
+                    <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QVBoxLayout" name="vtkFrameLayout">
                     <property name="spacing">
@@ -389,19 +389,19 @@
                 </property>
                 <layout class="QVBoxLayout" name="logPanelLayout">
                  <property name="spacing">
-                  <number>8</number>
+                  <number>12</number>
                  </property>
                  <property name="leftMargin">
-                  <number>0</number>
+                  <number>16</number>
                  </property>
                  <property name="topMargin">
-                  <number>0</number>
+                  <number>16</number>
                  </property>
                  <property name="rightMargin">
-                  <number>0</number>
+                  <number>16</number>
                  </property>
                  <property name="bottomMargin">
-                  <number>0</number>
+                  <number>16</number>
                  </property>
                  <item>
                   <widget class="QLabel" name="logTitle">

--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -19,29 +19,30 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     setFrameShape(QFrame::NoFrame);
     setCursor(Qt::PointingHandCursor);
     setStyleSheet(
-        "#schemeCard{background:#ffffff;border:1px solid #e4e7f1;"
-        "border-radius:14px;}"
-        "#schemeCard:hover{border:1px solid #1787ff;}"
-        "QLabel#titleLabel{font-weight:600;font-size:15px;color:#1b2b4d;}"
-        "QLabel#hintLabel{color:#8a93a6;font-size:12px;}"
-        "QLabel#imageLabel{background:#f6f7fb;border-radius:12px;"
-        "border:1px dashed #d0d6e5;color:#8a93a6;font-size:13px;"
+        "#schemeCard{background:#ffffff;border:1px solid #dce3f1;"
+        "border-radius:16px;}"
+        "#schemeCard:hover{border:1px solid #2563eb;}"
+        "QLabel#titleLabel{font-weight:600;font-size:15px;color:#0f172a;}"
+        "QLabel#hintLabel{color:#64748b;font-size:12px;}"
+        "QLabel#imageLabel{background:#f8fafc;border-radius:12px;"
+        "border:1px dashed #cbd5f5;color:#8a93b3;font-size:13px;"
         "padding:12px;line-height:20px;}"
         "QToolButton#openButton{border:none;border-radius:12px;padding:4px;"
-        "color:#0b57d0;background:rgba(11,87,208,0.08);}"
-        "QToolButton#openButton:hover{background:rgba(11,87,208,0.16);}"
+        "color:#2563eb;background:rgba(37,99,235,0.12);}" 
+        "QToolButton#openButton:hover{background:rgba(37,99,235,0.2);}" 
+        "QToolButton#openButton:pressed{background:rgba(37,99,235,0.28);}" 
         "QToolButton#deleteButton{border:none;border-radius:12px;"
-        "padding:4px;color:#d93025;"
-        "background:rgba(217,48,37,0.08);}"
-        "QToolButton#deleteButton:hover{background:rgba(217,48,37,0.16);}" );
+        "padding:4px;color:#ef4444;"
+        "background:rgba(239,68,68,0.12);}" 
+        "QToolButton#deleteButton:hover{background:rgba(239,68,68,0.2);}" );
 
     auto* shadow = new QGraphicsDropShadowEffect(this);
-    shadow->setBlurRadius(24);
-    shadow->setOffset(0, 8);
-    shadow->setColor(QColor(27, 43, 77, 30));
+    shadow->setBlurRadius(26);
+    shadow->setOffset(0, 10);
+    shadow->setColor(QColor(15, 23, 42, 28));
     setGraphicsEffect(shadow);
 
-    setMinimumSize(240, 300);
+    setMinimumSize(260, 300);
 
     auto *lay = new QVBoxLayout(this);
     lay->setContentsMargins(16,16,16,16);

--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -6,6 +6,7 @@
 #include <QScrollArea>
 #include <QPixmap>
 #include <QPushButton>
+#include <QFrame>
 
 #include <algorithm>
 
@@ -13,6 +14,35 @@ SchemeGalleryWidget::SchemeGalleryWidget(QWidget *parent)
     : QWidget(parent), ui(new Ui::SchemeGalleryWidget)
 {
     ui->setupUi(this);
+
+    if (ui->verticalLayout_root)
+    {
+        ui->verticalLayout_root->setContentsMargins(24, 24, 24, 24);
+        ui->verticalLayout_root->setSpacing(20);
+    }
+    if (ui->toolbarLayout)
+        ui->toolbarLayout->setSpacing(12);
+
+    if (ui->titleLabel)
+    {
+        ui->titleLabel->setStyleSheet(
+            "font-size:18px;font-weight:700;color:#0f172a;"
+            "padding:4px 0 4px 12px;border-left:4px solid #2563eb;"
+        );
+    }
+
+    if (ui->scrollArea)
+    {
+        ui->scrollArea->setFrameShape(QFrame::NoFrame);
+        ui->scrollArea->setStyleSheet(QStringLiteral(
+            "QScrollArea{background:transparent;border:none;}"
+        ));
+        if (auto* content = ui->scrollArea->widget())
+        {
+            content->setStyleSheet(QStringLiteral("background:transparent;"));
+            content->setAttribute(Qt::WA_StyledBackground, false);
+        }
+    }
 
     if (ui->newSchemeButton)
     {

--- a/SchemeSettingsDialog.cpp
+++ b/SchemeSettingsDialog.cpp
@@ -25,16 +25,20 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
 
     auto* v = new QVBoxLayout(this);
     v->setContentsMargins(16, 16, 16, 16);
-    v->setSpacing(12);
+    v->setSpacing(16);
 
     m_title = new QLabel(tr("正在编辑：%1").arg(schemeName), this);
-    m_title->setStyleSheet("font-weight:600;font-size:14px;");
+    m_title->setStyleSheet(
+        "font-weight:600;font-size:15px;color:#0f172a;"
+        "padding:4px 0 4px 12px;border-left:4px solid #2563eb;"
+    );
     v->addWidget(m_title);
 
     auto* nameRow = new QHBoxLayout();
     nameRow->addWidget(new QLabel(tr("方案名称："), this));
     m_nameEdit = new QLineEdit(schemeName, this);
     m_nameEdit->setPlaceholderText(tr("请输入方案名称"));
+    m_nameEdit->setClearButtonEnabled(true);
     nameRow->addWidget(m_nameEdit, 1);
     v->addLayout(nameRow);
 
@@ -50,11 +54,38 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     dirRow->addWidget(m_browseButton);
     v->addLayout(dirRow);
 
+    const QString lineEditStyle = QStringLiteral(
+        "QLineEdit{border:1px solid #d8dee9;border-radius:10px;padding:8px 10px;}"
+        "QLineEdit:focus{border:1px solid #2563eb;}"
+        "QLineEdit:read-only{background:#f1f5f9;color:#64748b;}"
+    );
+    m_nameEdit->setStyleSheet(lineEditStyle);
+    m_directoryEdit->setStyleSheet(lineEditStyle);
+
+    const QString primaryButtonStyle = QStringLiteral(
+        "QPushButton{padding:8px 18px;border-radius:14px;"
+        "background:#2563eb;color:#ffffff;font-weight:600;}"
+        "QPushButton:hover:enabled{background:#1d4ed8;}"
+        "QPushButton:pressed{background:#1e3a8a;}"
+        "QPushButton:disabled{background:#cbd5f5;color:#e2e8f0;}"
+    );
+    const QString dangerButtonStyle = QStringLiteral(
+        "QPushButton{padding:8px 18px;border-radius:14px;"
+        "background:rgba(239,68,68,0.12);color:#ef4444;font-weight:600;}"
+        "QPushButton:hover:enabled{background:rgba(239,68,68,0.2);}"
+        "QPushButton:pressed{background:rgba(239,68,68,0.28);}"
+        "QPushButton:disabled{background:rgba(239,68,68,0.08);color:rgba(239,68,68,0.55);}"
+    );
+    m_browseButton->setStyleSheet(primaryButtonStyle);
+
     if (allowDirectoryChange)
         connect(m_browseButton, &QPushButton::clicked, this, &SchemeSettingsDialog::browseForDirectory);
 
     auto* thumbTitle = new QLabel(tr("方案封面"), this);
-    thumbTitle->setStyleSheet("font-weight:600;");
+    thumbTitle->setStyleSheet(
+        "font-weight:600;color:#0f172a;padding:4px 0 4px 12px;"
+        "border-left:3px solid #2563eb;"
+    );
     v->addWidget(thumbTitle);
 
     auto* thumbRow = new QHBoxLayout();
@@ -65,19 +96,21 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     m_thumbnailPreview->setMinimumSize(260, 160);
     m_thumbnailPreview->setAlignment(Qt::AlignCenter);
     m_thumbnailPreview->setWordWrap(true);
-    m_thumbnailPreview->setStyleSheet("background:#f6f7fb;"
-                                      "border:1px dashed #d0d6e5;"
-                                      "border-radius:8px;"
-                                      "color:#8a93a6;"
-                                      "padding:12px;line-height:20px;");
+    m_thumbnailPreview->setStyleSheet("background:#f8fafc;"
+                                      "border:1px dashed #cbd5f5;"
+                                      "border-radius:12px;"
+                                      "color:#64748b;"
+                                      "padding:14px;line-height:20px;");
     thumbRow->addWidget(m_thumbnailPreview, 1);
 
     auto* thumbButtons = new QVBoxLayout();
     thumbButtons->setContentsMargins(0, 0, 0, 0);
     thumbButtons->setSpacing(8);
     m_thumbnailButton = new QPushButton(tr("选择图片..."), this);
+    m_thumbnailButton->setStyleSheet(primaryButtonStyle);
     thumbButtons->addWidget(m_thumbnailButton);
     m_clearThumbnailButton = new QPushButton(tr("清除图片"), this);
+    m_clearThumbnailButton->setStyleSheet(dangerButtonStyle);
     thumbButtons->addWidget(m_clearThumbnailButton);
     thumbButtons->addStretch(1);
     thumbRow->addLayout(thumbButtons, 0);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -169,12 +169,28 @@ void MainWindow::setupUiHelpers()
     ui->planPageLayout->addWidget(m_galleryWidget);
 
     auto* detailLayout = new QVBoxLayout(ui->settingWidget);
-    detailLayout->setContentsMargins(12, 12, 12, 12);
-    detailLayout->setSpacing(12);
+    detailLayout->setContentsMargins(16, 16, 16, 16);
+    detailLayout->setSpacing(16);
+
+    ui->centralwidget->setStyleSheet(QStringLiteral(
+        "#centralwidget{background:#eef2f8;}"
+        "#navigationFrame,#detailPanel,#vtkPanel,#logPanel{"
+        "background:#ffffff;border:1px solid #d8dee9;border-radius:18px;}"
+        "#vtkFrame{background:#f8fafc;border:1px solid #d8dee9;border-radius:14px;}"
+    ));
+    const QList<QWidget*> styledPanels = {ui->navigationFrame, ui->detailPanel,
+                                          ui->vtkPanel, ui->logPanel,
+                                          ui->vtkFrame};
+    for (QWidget* panel : styledPanels)
+    {
+        if (panel)
+            panel->setAttribute(Qt::WA_StyledBackground, true);
+    }
 
     const QString sectionTitleStyle = QStringLiteral(
-        "font-size:15px;font-weight:600;color:#0f172a;"
-        "background:#e2e8f0;border-radius:8px;padding:6px 12px;");
+        "font-size:16px;font-weight:600;color:#0f172a;"
+        "padding:4px 0 4px 12px;border-left:4px solid #2563eb;"
+        "background:transparent;letter-spacing:0.2px;");
     const auto applySectionStyle = [&](QLabel* label) {
         if (label)
             label->setStyleSheet(sectionTitleStyle);
@@ -184,10 +200,36 @@ void MainWindow::setupUiHelpers()
     applySectionStyle(ui->vtkTitle);
     applySectionStyle(ui->logTitle);
 
+    const QString splitterStyle = QStringLiteral(
+        "QSplitter::handle:horizontal{width:10px;background:rgba(15,23,42,0.08);"
+        "margin:0 4px;border-radius:4px;}"
+        "QSplitter::handle:horizontal:hover{background:rgba(37,99,235,0.35);}" 
+        "QSplitter::handle:vertical{height:10px;background:rgba(15,23,42,0.08);"
+        "margin:4px 0;border-radius:4px;}"
+        "QSplitter::handle:vertical:hover{background:rgba(37,99,235,0.35);}" );
+    ui->mainSplitter->setStyleSheet(splitterStyle);
+    ui->contentSplitter->setStyleSheet(splitterStyle);
+    if (ui->visualizationSplitter)
+        ui->visualizationSplitter->setStyleSheet(splitterStyle);
+
+    ui->mainSplitter->setHandleWidth(10);
+    ui->contentSplitter->setHandleWidth(10);
+    if (ui->visualizationSplitter)
+        ui->visualizationSplitter->setHandleWidth(10);
+
     ui->treeModels->header()->setStretchLastSection(true);
     ui->treeModels->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeModels->setEditTriggers(QAbstractItemView::EditKeyPressed |
                                     QAbstractItemView::SelectedClicked);
+    ui->treeModels->setIndentation(18);
+    ui->treeModels->setStyleSheet(QStringLiteral(
+        "QTreeWidget{background:transparent;border:none;padding:4px;}"
+        "QTreeView::branch{background:transparent;}"
+        "QTreeView::item{height:26px;padding:4px 8px;margin:2px;border-radius:8px;}"
+        "QTreeView::item:!selected:alternate{background:rgba(15,23,42,0.04);}" 
+        "QTreeView::item:hover{background:rgba(37,99,235,0.12);}" 
+        "QTreeView::item:selected{background:#2563eb;color:#ffffff;}"
+        "QTreeView::item:selected:!active{background:#2563eb;color:#ffffff;}"));
 
     ui->mainSplitter->setStretchFactor(0, 0);
     ui->mainSplitter->setStretchFactor(1, 1);
@@ -198,11 +240,16 @@ void MainWindow::setupUiHelpers()
     {
         ui->visualizationSplitter->setStretchFactor(0, 3);
         ui->visualizationSplitter->setStretchFactor(1, 1);
-        ui->visualizationSplitter->setHandleWidth(6);
     }
 
     ui->logTextEdit->setStyleSheet(
-        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border-radius:6px;padding:6px;}"
+        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border-radius:14px;padding:12px;"
+        "font-family:\"JetBrains Mono\",\"Cascadia Code\",\"Consolas\",monospace;font-size:12px;}"
+        "QPlainTextEdit QScrollBar:vertical{background:transparent;width:12px;margin:4px;}"
+        "QPlainTextEdit QScrollBar::handle:vertical{background:rgba(148,163,184,0.6);"
+        "border-radius:6px;}"
+        "QPlainTextEdit QScrollBar::handle:vertical:hover{background:rgba(37,99,235,0.8);}" 
+        "QPlainTextEdit QScrollBar::add-line:vertical,QPlainTextEdit QScrollBar::sub-line:vertical{height:0;}"
     );
 
     setVisualizationVisible(false);


### PR DESCRIPTION
## Summary
- give the main workspace panels cohesive padding, accent headers, and updated splitter/log styles
- refresh the scheme gallery cards and layout to match the new visual language
- restyle the scheme settings dialog inputs and action buttons for a consistent palette

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0f32ca7b8832da3c2b4a482a4eade