### PR TITLE
Fix navigation tree resizing

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -184,6 +184,10 @@ void MainWindow::setupUiHelpers()
     applySectionStyle(ui->vtkTitle);
     applySectionStyle(ui->logTitle);
 
+    const int navigationWidth = std::max(ui->navigationFrame->sizeHint().width(),
+                                         ui->treeModels->minimumWidth());
+    ui->navigationFrame->setFixedWidth(navigationWidth);
+
     ui->treeModels->header()->setStretchLastSection(true);
     ui->treeModels->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->treeModels->setEditTriggers(QAbstractItemView::EditKeyPressed |


### PR DESCRIPTION
## Summary
- lock the navigation frame width so the model tree pane cannot be resized from the navigation splitter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0fded0774832d8fa39f509805ac0d