### PR TITLE
Remove STEP file handling

### DIFF
--- a/JsonPageBuilder.cpp
+++ b/JsonPageBuilder.cpp
@@ -20,16 +20,9 @@ namespace
 {
 QFileInfo latestResultInfo(const QDir& dir)
 {
-    const QStringList stepPatterns{ QStringLiteral("*.step"), QStringLiteral("*.STEP"),
-                                    QStringLiteral("*.stp"), QStringLiteral("*.STP") };
-    QFileInfoList files = dir.entryInfoList(stepPatterns, QDir::Files,
-                                            QDir::Time | QDir::IgnoreCase);
-    if (!files.isEmpty())
-        return files.first();
-
     const QStringList stlPatterns{ QStringLiteral("*.stl"), QStringLiteral("*.STL") };
-    files = dir.entryInfoList(stlPatterns, QDir::Files,
-                              QDir::Time | QDir::IgnoreCase);
+    QFileInfoList files = dir.entryInfoList(stlPatterns, QDir::Files,
+                                            QDir::Time | QDir::IgnoreCase);
     if (!files.isEmpty())
         return files.first();
     return QFileInfo();
@@ -461,12 +454,8 @@ void JsonPageBuilder::onCalculateButtonClicked()
         if (isNewFile || isUpdated)
         {
             newResultPath = latestResult.absoluteFilePath();
-            const QString suffix = latestResult.suffix().toLower();
-            const QString fileType = (suffix == QStringLiteral("stl")) ? QStringLiteral("STL")
-                                                                       : QStringLiteral("STEP");
-            emit logMessage(tr("检测到新的 %1 输出：%2")
-                                .arg(fileType,
-                                     QDir::toNativeSeparators(newResultPath)));
+            emit logMessage(tr("检测到新的 STL 输出：%1")
+                                .arg(QDir::toNativeSeparators(newResultPath)));
         }
     }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -37,7 +37,6 @@
 #include <QProcess>
 #include <QPushButton>
 #include <QRegularExpression>
-#include <QTextStream>
 #include <QScopedValueRollback>
 #include <QScrollBar>
 #include <QScrollArea>
@@ -55,7 +54,6 @@
 #include <QWidget>
 #include <algorithm>
 #include <cmath>
-#include <limits>
 
 #include <QVTKOpenGLNativeWidget.h>
 #include <vtkActor.h>
@@ -67,7 +65,6 @@
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkSTLReader.h>
-#include <vtkCubeSource.h>
 
 namespace
 {
@@ -134,92 +131,12 @@ QString uniqueChildPath(const QDir& parent, const QString& baseName)
 QString latestResultFile(const QString& directory)
 {
     QDir dir(directory);
-    const QStringList stepPatterns{ QStringLiteral("*.step"), QStringLiteral("*.STEP"),
-                                    QStringLiteral("*.stp"), QStringLiteral("*.STP") };
-    QFileInfoList files = dir.entryInfoList(stepPatterns, QDir::Files,
+    const QStringList stlPatterns{ QStringLiteral("*.stl"), QStringLiteral("*.STL") };
+    QFileInfoList files = dir.entryInfoList(stlPatterns, QDir::Files,
                                             QDir::Time | QDir::IgnoreCase);
     if (!files.isEmpty())
         return files.first().absoluteFilePath();
-
-    const QStringList stlPatterns{ QStringLiteral("*.stl"), QStringLiteral("*.STL") };
-    files = dir.entryInfoList(stlPatterns, QDir::Files,
-                              QDir::Time | QDir::IgnoreCase);
-    if (!files.isEmpty())
-        return files.first().absoluteFilePath();
     return QString();
-}
-
-bool extractBoundingBoxFromStep(const QString& filePath,
-                                QVector3D* minPoint,
-                                QVector3D* maxPoint)
-{
-    if (!minPoint || !maxPoint)
-        return false;
-
-    QFile file(filePath);
-    if (!file.exists() || !file.open(QIODevice::ReadOnly | QIODevice::Text))
-        return false;
-
-    QTextStream stream(&file);
-    stream.setCodec("UTF-8");
-    const QString content = stream.readAll();
-    file.close();
-
-    const QRegularExpression pointRe(
-        QStringLiteral("CARTESIAN_POINT\\s*\\([^\\)]*\\(\\s*([^\\)]+)\\)\\s*\\)"),
-        QRegularExpression::CaseInsensitiveOption |
-            QRegularExpression::DotMatchesEverythingOption);
-    const QRegularExpression numberRe(
-        QStringLiteral("(-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"));
-
-    auto pointIt = pointRe.globalMatch(content);
-    double minX = std::numeric_limits<double>::max();
-    double minY = std::numeric_limits<double>::max();
-    double minZ = std::numeric_limits<double>::max();
-    double maxX = std::numeric_limits<double>::lowest();
-    double maxY = std::numeric_limits<double>::lowest();
-    double maxZ = std::numeric_limits<double>::lowest();
-    bool hasPoint = false;
-
-    while (pointIt.hasNext())
-    {
-        const QString coords = pointIt.next().captured(1);
-        auto numIt = numberRe.globalMatch(coords);
-        QVector<double> values;
-        while (numIt.hasNext())
-        {
-            bool ok = false;
-            const QString token = numIt.next().captured(1);
-            const double value = token.toDouble(&ok);
-            if (ok)
-                values.push_back(value);
-        }
-
-        for (int i = 0; i + 2 < values.size(); i += 3)
-        {
-            const double x = values.at(i);
-            const double y = values.at(i + 1);
-            const double z = values.at(i + 2);
-            minX = std::min(minX, x);
-            minY = std::min(minY, y);
-            minZ = std::min(minZ, z);
-            maxX = std::max(maxX, x);
-            maxY = std::max(maxY, y);
-            maxZ = std::max(maxZ, z);
-            hasPoint = true;
-        }
-    }
-
-    if (!hasPoint)
-        return false;
-
-    *minPoint = QVector3D(static_cast<float>(minX),
-                          static_cast<float>(minY),
-                          static_cast<float>(minZ));
-    *maxPoint = QVector3D(static_cast<float>(maxX),
-                          static_cast<float>(maxY),
-                          static_cast<float>(maxZ));
-    return true;
 }
 }
 
@@ -1511,12 +1428,8 @@ void MainWindow::showModelSettings(const QString& modelId)
     const QString resultPath = latestResultFile(model->directory);
     if (!resultPath.isEmpty())
     {
-        const QString suffix = QFileInfo(resultPath).suffix().toLower();
-        const QString fileType = (suffix == QStringLiteral("stl")) ? QStringLiteral("STL")
-                                                                   : QStringLiteral("STEP");
-        appendLogMessage(tr("加载最近的 %1：%2")
-                             .arg(fileType,
-                                  QDir::toNativeSeparators(resultPath)));
+        appendLogMessage(tr("加载最近的 STL：%1")
+                             .arg(QDir::toNativeSeparators(resultPath)));
         displayResultFile(resultPath);
     }
     else
@@ -1646,12 +1559,8 @@ QWidget* MainWindow::buildModelSettingsWidget(const ModelRecord& model)
             appendLogMessage(tr("未检测到新的输出文件"));
             return;
         }
-        const QString suffix = QFileInfo(resultPath).suffix().toLower();
-        const QString fileType = (suffix == QStringLiteral("stl")) ? QStringLiteral("STL")
-                                                                   : QStringLiteral("STEP");
-        appendLogMessage(tr("加载 %1：%2")
-                             .arg(fileType,
-                                  QDir::toNativeSeparators(resultPath)));
+        appendLogMessage(tr("加载 STL：%1")
+                             .arg(QDir::toNativeSeparators(resultPath)));
         displayResultFile(resultPath);
     });
 
@@ -3686,36 +3595,6 @@ void MainWindow::displayResultFile(const QString& filePath)
         actor->GetProperty()->SetColor(0.2, 0.45, 0.75);
         actor->GetProperty()->SetDiffuse(0.8);
         actor->GetProperty()->SetSpecular(0.3);
-    }
-    else if (suffix == QStringLiteral("step") || suffix == QStringLiteral("stp"))
-    {
-        QVector3D minPoint;
-        QVector3D maxPoint;
-        if (!extractBoundingBoxFromStep(info.absoluteFilePath(), &minPoint, &maxPoint))
-        {
-            appendLogMessage(tr("无法解析 STEP 文件：%1")
-                                 .arg(QDir::toNativeSeparators(info.absoluteFilePath())));
-            return;
-        }
-
-        const QVector3D lengths = maxPoint - minPoint;
-        const QVector3D center = (minPoint + maxPoint) * 0.5f;
-        const double minEdge = 1.0;
-
-        auto cube = vtkSmartPointer<vtkCubeSource>::New();
-        cube->SetCenter(center.x(), center.y(), center.z());
-        cube->SetXLength(std::max(minEdge, std::abs(static_cast<double>(lengths.x()))));
-        cube->SetYLength(std::max(minEdge, std::abs(static_cast<double>(lengths.y()))));
-        cube->SetZLength(std::max(minEdge, std::abs(static_cast<double>(lengths.z()))));
-
-        auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-        mapper->SetInputConnection(cube->GetOutputPort());
-
-        actor = vtkSmartPointer<vtkActor>::New();
-        actor->SetMapper(mapper);
-        actor->GetProperty()->SetRepresentationToWireframe();
-        actor->GetProperty()->SetColor(0.2, 0.45, 0.75);
-        actor->GetProperty()->SetLineWidth(1.5);
     }
     else
     {


### PR DESCRIPTION
## Summary
- remove STEP result detection and bounding box fallback in the main window
- ensure only STL files are discovered and logged across the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d20f83b934832d953eefab04f86f9d