### PR TITLE
style: unify scheme gallery title with other panels

### DIFF
--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -2,10 +2,12 @@
 #include "ui_SchemeGalleryWidget.h"   // 由 .ui 生成
 #include "SchemeCardWidget.h"
 
+#include <QFrame>
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QPixmap>
 #include <QPushButton>
+#include <QWidget>
 
 #include <algorithm>
 
@@ -13,6 +15,24 @@ SchemeGalleryWidget::SchemeGalleryWidget(QWidget *parent)
     : QWidget(parent), ui(new Ui::SchemeGalleryWidget)
 {
     ui->setupUi(this);
+
+    if (auto* panel = findChild<QFrame*>(QStringLiteral("galleryPanel")))
+    {
+        panel->setAttribute(Qt::WA_StyledBackground, true);
+        panel->setStyleSheet(
+            "QFrame#galleryPanel{background:#ffffff;border:1px solid #d6e1f2;border-radius:14px;}"
+            "QWidget#toolbarWidget{background:#f8fafc;padding:12px 16px;border-top-left-radius:14px;border-top-right-radius:14px;}"
+            "QLabel#titleLabel{font-size:15px;font-weight:600;color:#0f172a;}"
+            "QScrollArea{border:none;background:transparent;}"
+            "QWidget#scrollAreaWidgetContents{background:transparent;}"
+        );
+    }
+
+    if (auto* header = findChild<QWidget*>(QStringLiteral("toolbarWidget")))
+        header->setAttribute(Qt::WA_StyledBackground, true);
+
+    if (ui->scrollArea)
+        ui->scrollArea->setFrameShape(QFrame::NoFrame);
 
     if (ui->newSchemeButton)
     {

--- a/SchemeGalleryWidget.ui
+++ b/SchemeGalleryWidget.ui
@@ -30,87 +30,134 @@
     <number>8</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="toolbarLayout">
-     <item>
-      <widget class="QLabel" name="titleLabel">
-       <property name="styleSheet">
-        <string notr="true">font-size:16px; font-weight:600;</string>
-       </property>
-       <property name="text">
-        <string>方案库</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="toolbarSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="newSchemeButton">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>新建方案</string>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
+    <widget class="QFrame" name="galleryPanel">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>293</width>
-        <height>701</height>
-       </rect>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QVBoxLayout" name="panelLayout">
+      <property name="spacing">
+       <number>0</number>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>8</number>
-       </property>
-       <property name="topMargin">
-        <number>8</number>
-       </property>
-       <property name="rightMargin">
-        <number>8</number>
-       </property>
-       <property name="bottomMargin">
-        <number>8</number>
-       </property>
-       <property name="spacing">
-        <number>16</number>
-       </property>
-      </layout>
-     </widget>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="toolbarWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="toolbarLayout">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="titleLabel">
+           <property name="text">
+            <string>方案库</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="toolbarSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="newSchemeButton">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>新建方案</string>
+           </property>
+           <property name="icon">
+            <iconset resource="resources.qrc">
+             <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>16</width>
+             <height>16</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>293</width>
+           <height>701</height>
+          </rect>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="leftMargin">
+           <number>8</number>
+          </property>
+          <property name="topMargin">
+           <number>8</number>
+          </property>
+          <property name="rightMargin">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
+           <number>8</number>
+          </property>
+          <property name="spacing">
+           <number>16</number>
+          </property>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Summary
- wrap the scheme gallery contents in a card-style frame so the header can match other panels
- apply the shared typography and background styling to the gallery header and scroll area for visual consistency

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2532e9700832da97bacc09d5bfd5c