### PR TITLE
Align scheme gallery header styling

### DIFF
--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -2,10 +2,11 @@
 #include "ui_SchemeGalleryWidget.h"   // 由 .ui 生成
 #include "SchemeCardWidget.h"
 
+#include <QFrame>
 #include <QGridLayout>
-#include <QScrollArea>
 #include <QPixmap>
 #include <QPushButton>
+#include <QScrollArea>
 
 #include <algorithm>
 
@@ -14,15 +15,39 @@ SchemeGalleryWidget::SchemeGalleryWidget(QWidget *parent)
 {
     ui->setupUi(this);
 
+    setAttribute(Qt::WA_StyledBackground, true);
+    if (ui->headerFrame)
+        ui->headerFrame->setAttribute(Qt::WA_StyledBackground, true);
+    if (ui->scrollArea)
+    {
+        ui->scrollArea->setFrameShape(QFrame::NoFrame);
+        ui->scrollArea->setAttribute(Qt::WA_StyledBackground, true);
+        if (auto* viewport = ui->scrollArea->viewport())
+        {
+            viewport->setAttribute(Qt::WA_StyledBackground, true);
+            viewport->setStyleSheet(QStringLiteral("background:transparent;"));
+        }
+        if (auto* contents = ui->scrollArea->widget())
+            contents->setAttribute(Qt::WA_StyledBackground, true);
+    }
+
+    const QString style = QStringLiteral(
+        "QWidget#SchemeGalleryWidget{background:#ffffff;border:1px solid #d6e1f2;border-radius:14px;}"
+        "QFrame#headerFrame{background:#f8fafc;border-top-left-radius:14px;border-top-right-radius:14px;"
+        "border-bottom:1px solid #e2e8f0;}"
+        "QLabel#titleLabel{font-size:15px;font-weight:600;color:#0f172a;padding:12px 16px;}"
+        "QPushButton#newSchemeButton{padding:6px 14px;border-radius:16px;background-color:#1d4ed8;color:white;"
+        "font-weight:600;margin:8px 16px 8px 0;}"
+        "QPushButton#newSchemeButton:hover{background-color:#2563eb;}"
+        "QPushButton#newSchemeButton:pressed{background-color:#1e3a8a;}"
+        "QScrollArea{border:none;background:transparent;}"
+        "QWidget#scrollAreaWidgetContents{background:transparent;}"
+    );
+    setStyleSheet(style);
+
     if (ui->newSchemeButton)
     {
         ui->newSchemeButton->setCursor(Qt::PointingHandCursor);
-        ui->newSchemeButton->setStyleSheet(
-            "QPushButton{padding:6px 14px;border-radius:16px;"
-            "background-color:#1d4ed8;color:white;font-weight:600;}"
-            "QPushButton:hover{background-color:#2563eb;}"
-            "QPushButton:pressed{background-color:#1e3a8a;}"
-        );
         connect(ui->newSchemeButton, &QPushButton::clicked,
                 this, &SchemeGalleryWidget::createSchemeRequested);
     }

--- a/SchemeGalleryWidget.ui
+++ b/SchemeGalleryWidget.ui
@@ -15,69 +15,95 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_root">
    <property name="spacing">
-    <number>8</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
-    <number>8</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>8</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>8</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>8</number>
+    <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="toolbarLayout">
-     <item>
-      <widget class="QLabel" name="titleLabel">
-       <property name="styleSheet">
-        <string notr="true">font-size:16px; font-weight:600;</string>
-       </property>
-       <property name="text">
-        <string>方案库</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="toolbarSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="newSchemeButton">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>新建方案</string>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QFrame" name="headerFrame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="toolbarLayout">
+      <property name="spacing">
+       <number>8</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="titleLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>方案库</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="toolbarSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="newSchemeButton">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>新建方案</string>
+        </property>
+        <property name="icon">
+         <iconset resource="resources.qrc">
+          <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -95,16 +121,16 @@
       </property>
       <layout class="QGridLayout" name="gridLayout">
        <property name="leftMargin">
-        <number>8</number>
+        <number>16</number>
        </property>
        <property name="topMargin">
-        <number>8</number>
+        <number>16</number>
        </property>
        <property name="rightMargin">
-        <number>8</number>
+        <number>16</number>
        </property>
        <property name="bottomMargin">
-        <number>8</number>
+        <number>16</number>
        </property>
        <property name="spacing">
         <number>16</number>


### PR DESCRIPTION
## Summary
- wrap the scheme gallery header in a framed toolbar and adjust layout margins so the gallery can share the global card styling
- apply a unified stylesheet to the gallery title bar and action button so the library page matches other panels

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2532e9700832da97bacc09d5bfd5c