### PR TITLE
Align scheme library header styling

### DIFF
--- a/SchemeGalleryWidget.cpp
+++ b/SchemeGalleryWidget.cpp
@@ -2,6 +2,7 @@
 #include "ui_SchemeGalleryWidget.h"   // 由 .ui 生成
 #include "SchemeCardWidget.h"
 
+#include <QFrame>
 #include <QGridLayout>
 #include <QScrollArea>
 #include <QPixmap>
@@ -13,6 +14,31 @@ SchemeGalleryWidget::SchemeGalleryWidget(QWidget *parent)
     : QWidget(parent), ui(new Ui::SchemeGalleryWidget)
 {
     ui->setupUi(this);
+
+    setAttribute(Qt::WA_StyledBackground, true);
+    if (ui->containerFrame)
+        ui->containerFrame->setAttribute(Qt::WA_StyledBackground, true);
+    if (ui->toolbarWidget)
+        ui->toolbarWidget->setAttribute(Qt::WA_StyledBackground, true);
+
+    const QString styleSheet = QStringLiteral(
+        "QFrame#containerFrame{background:#ffffff;border:1px solid #d6e1f2;border-radius:14px;}"
+        "QWidget#toolbarWidget{background:#f8fafc;border-top-left-radius:14px;border-top-right-radius:14px;"
+        "border-bottom:1px solid #e2e8f0;padding:12px 16px;}"
+        "QLabel#titleLabel{font-size:15px;font-weight:600;color:#0f172a;}"
+        "QScrollArea{border:none;background:transparent;}"
+        "QWidget#scrollAreaWidgetContents{background:transparent;}"
+    );
+    setStyleSheet(styleSheet);
+
+    if (ui->scrollArea)
+    {
+        ui->scrollArea->setFrameShape(QFrame::NoFrame);
+        if (QWidget* viewport = ui->scrollArea->viewport())
+        {
+            viewport->setStyleSheet(QStringLiteral("background:transparent;"));
+        }
+    }
 
     if (ui->newSchemeButton)
     {

--- a/SchemeGalleryWidget.ui
+++ b/SchemeGalleryWidget.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_root">
    <property name="spacing">
-    <number>8</number>
+    <number>0</number>
    </property>
    <property name="leftMargin">
     <number>8</number>
@@ -30,87 +30,134 @@
     <number>8</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="toolbarLayout">
-     <item>
-      <widget class="QLabel" name="titleLabel">
-       <property name="styleSheet">
-        <string notr="true">font-size:16px; font-weight:600;</string>
-       </property>
-       <property name="text">
-        <string>方案库</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="toolbarSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="newSchemeButton">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>新建方案</string>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
+    <widget class="QFrame" name="containerFrame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>293</width>
-        <height>701</height>
-       </rect>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QVBoxLayout" name="containerLayout">
+      <property name="spacing">
+       <number>0</number>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>8</number>
-       </property>
-       <property name="topMargin">
-        <number>8</number>
-       </property>
-       <property name="rightMargin">
-        <number>8</number>
-       </property>
-       <property name="bottomMargin">
-        <number>8</number>
-       </property>
-       <property name="spacing">
-        <number>16</number>
-       </property>
-      </layout>
-     </widget>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="toolbarWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="toolbarLayout">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="titleLabel">
+           <property name="text">
+            <string>方案库</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="toolbarSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="newSchemeButton">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>32</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>新建方案</string>
+           </property>
+           <property name="icon">
+            <iconset resource="resources.qrc">
+             <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>16</width>
+             <height>16</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>293</width>
+           <height>701</height>
+          </rect>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="leftMargin">
+           <number>8</number>
+          </property>
+          <property name="topMargin">
+           <number>8</number>
+          </property>
+          <property name="rightMargin">
+           <number>8</number>
+          </property>
+          <property name="bottomMargin">
+           <number>8</number>
+          </property>
+          <property name="spacing">
+           <number>16</number>
+          </property>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Summary
- wrap the scheme gallery in a framed container with a dedicated toolbar widget
- apply the shared card header styling so the scheme library title matches other pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2532e9700832da97bacc09d5bfd5c