### PR TITLE
Refine parameter layout styling

### DIFF
--- a/JsonPageBuilder.cpp
+++ b/JsonPageBuilder.cpp
@@ -30,14 +30,33 @@ QFileInfo latestResultInfo(const QDir& dir)
 }
 }
 
-static const char* kBtnQss =
+static const char* kSectionButtonQss =
     "QPushButton {"
-    "  background-color: #e0e9f4;"
-    "  color: black;"
-    "  border: none;"
+    "  background-color: #eef2f6;"
+    "  color: #111827;"
+    "  border: 1px solid #d6dae2;"
+    "  border-radius: 10px;"
     "  text-align: left;"
-    "  font-size: 15pt;"
-    "}";
+    "  font-size: 16px;"
+    "  font-weight: 600;"
+    "  padding: 10px 14px;"
+    "}"
+    "QPushButton:hover { background-color: #e2e7ee; }"
+    "QPushButton:pressed { background-color: #d6dde5; }";
+
+static const char* kPrimaryButtonQss =
+    "QPushButton {"
+    "  background-color: #2563eb;"
+    "  color: #ffffff;"
+    "  border: none;"
+    "  border-radius: 10px;"
+    "  font-size: 15px;"
+    "  font-weight: 600;"
+    "  padding: 10px 16px;"
+    "}"
+    "QPushButton:disabled { background-color: #93c5fd; color: #ffffff; }"
+    "QPushButton:hover:!disabled { background-color: #1d4ed8; }"
+    "QPushButton:pressed:!disabled { background-color: #1e40af; }";
 
 JsonPageBuilder::JsonPageBuilder(const QString& jsonPath, QWidget* parent)
     : QWidget(parent)
@@ -87,9 +106,15 @@ JsonPageBuilder::JsonPageBuilder(const QString& jsonPath, QWidget* parent)
 
 void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
 {
+    setStyleSheet(QStringLiteral(
+        "QWidget{background:#ffffff;}"
+        "QLineEdit{border:1px solid #d6dae2;border-radius:8px;padding:6px 10px;font-size:14px;color:#111827;}"
+        "QLineEdit:focus{border:1px solid #2563eb;}"
+    ));
+
     auto* mainLayout = new QVBoxLayout(this);
-    mainLayout->setSpacing(12);
-    mainLayout->setContentsMargins(10, 10, 10, 10);
+    mainLayout->setSpacing(16);
+    mainLayout->setContentsMargins(18, 18, 18, 18);
 
     for (int i = 0; i < sections.size(); ++i)
     {
@@ -99,7 +124,8 @@ void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
         // 标题按钮
         auto* titleBtn = new QPushButton(title, this);
         titleBtn->setMinimumHeight(40);
-        titleBtn->setStyleSheet(kBtnQss);
+        titleBtn->setCursor(Qt::PointingHandCursor);
+        titleBtn->setStyleSheet(kSectionButtonQss);
         mainLayout->addWidget(titleBtn);
         m_titleButtons.push_back(titleBtn);
 
@@ -122,6 +148,7 @@ void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
 
             auto* lab = new QLabel(cnName + QString("："), this);
             lab->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+            lab->setStyleSheet(QStringLiteral("font-size:13px;color:#4b5563;font-weight:500;"));
 
             auto* edit = new QLineEdit(this);
             // JSON 值回显为字符串
@@ -157,6 +184,8 @@ void JsonPageBuilder::buildUiFromJson(const QJsonArray& sections)
     // 计算按钮
     m_calculateButton = new QPushButton(QString("计算"), this);
     m_calculateButton->setMinimumHeight(40);
+    m_calculateButton->setCursor(Qt::PointingHandCursor);
+    m_calculateButton->setStyleSheet(kPrimaryButtonQss);
     connect(m_calculateButton, &QPushButton::clicked,
             this, &JsonPageBuilder::onCalculateButtonClicked);
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -122,6 +122,7 @@ private:
     void displayResultFile(const QString& filePath);
     void clearVtkScene();
     QString projectDisplayName() const;
+    QList<int> defaultContentSplitterSizes() const;
 
     SchemeRecord* schemeById(const QString& id);
     const SchemeRecord* schemeById(const QString& id) const;

--- a/SchemeSettingsDialog.cpp
+++ b/SchemeSettingsDialog.cpp
@@ -23,16 +23,29 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     setWindowTitle(tr("总成设置"));
     resize(520, 360);
 
+    setStyleSheet(QStringLiteral(
+        "QDialog{background:#ffffff;}"
+        "QLabel{color:#1f2937;}"
+        "QLineEdit{border:1px solid #d6dae2;border-radius:8px;padding:6px 10px;font-size:14px;color:#111827;}"
+        "QLineEdit:disabled{background:#f3f4f6;color:#9ca3af;}"
+        "QPushButton{background:#2563eb;color:#ffffff;border:none;border-radius:8px;padding:8px 14px;font-size:14px;font-weight:600;}"
+        "QPushButton:disabled{background:#93c5fd;color:#ffffff;}"
+        "QPushButton:hover:!disabled{background:#1d4ed8;}"
+        "QPushButton:pressed:!disabled{background:#1e40af;}"
+    ));
+
     auto* v = new QVBoxLayout(this);
     v->setContentsMargins(16, 16, 16, 16);
     v->setSpacing(12);
 
     m_title = new QLabel(tr("正在编辑：%1").arg(schemeName), this);
-    m_title->setStyleSheet("font-weight:600;font-size:14px;");
+    m_title->setStyleSheet("font-weight:600;font-size:18px;color:#111827;");
     v->addWidget(m_title);
 
     auto* nameRow = new QHBoxLayout();
-    nameRow->addWidget(new QLabel(tr("总成名称："), this));
+    auto* nameLabel = new QLabel(tr("总成名称："), this);
+    nameLabel->setStyleSheet(QStringLiteral("font-size:14px;font-weight:500;color:#374151;"));
+    nameRow->addWidget(nameLabel);
     m_nameEdit = new QLineEdit(schemeName, this);
     m_nameEdit->setPlaceholderText(tr("请输入总成名称"));
     nameRow->addWidget(m_nameEdit, 1);
@@ -40,7 +53,9 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
 
     auto* dirRow = new QHBoxLayout();
     dirRow->setSpacing(8);
-    dirRow->addWidget(new QLabel(tr("工作目录："), this));
+    auto* dirLabel = new QLabel(tr("工作目录："), this);
+    dirLabel->setStyleSheet(QStringLiteral("font-size:14px;font-weight:500;color:#374151;"));
+    dirRow->addWidget(dirLabel);
     m_directoryEdit = new QLineEdit(workingDirectory, this);
     m_directoryEdit->setPlaceholderText(tr("请选择模型计算的工作目录"));
     m_directoryEdit->setReadOnly(!allowDirectoryChange);
@@ -54,7 +69,7 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
         connect(m_browseButton, &QPushButton::clicked, this, &SchemeSettingsDialog::browseForDirectory);
 
     auto* thumbTitle = new QLabel(tr("总成封面"), this);
-    thumbTitle->setStyleSheet("font-weight:600;");
+    thumbTitle->setStyleSheet("font-weight:600;font-size:15px;color:#111827;");
     v->addWidget(thumbTitle);
 
     auto* thumbRow = new QHBoxLayout();
@@ -65,16 +80,16 @@ SchemeSettingsDialog::SchemeSettingsDialog(const QString& schemeName,
     m_thumbnailPreview->setMinimumSize(260, 160);
     m_thumbnailPreview->setAlignment(Qt::AlignCenter);
     m_thumbnailPreview->setWordWrap(true);
-    m_thumbnailPreview->setStyleSheet("background:#f6f7fb;"
-                                      "border:1px dashed #d0d6e5;"
-                                      "border-radius:8px;"
-                                      "color:#8a93a6;"
+    m_thumbnailPreview->setStyleSheet("background:#f9fafc;"
+                                      "border:1px dashed #d6dae2;"
+                                      "border-radius:10px;"
+                                      "color:#6b7280;"
                                       "padding:12px;line-height:20px;");
     thumbRow->addWidget(m_thumbnailPreview, 1);
 
     auto* thumbButtons = new QVBoxLayout();
     thumbButtons->setContentsMargins(0, 0, 0, 0);
-    thumbButtons->setSpacing(8);
+    thumbButtons->setSpacing(12);
     m_thumbnailButton = new QPushButton(tr("选择图片..."), this);
     thumbButtons->addWidget(m_thumbnailButton);
     m_clearThumbnailButton = new QPushButton(tr("清除图片"), this);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -172,7 +172,7 @@ void MainWindow::setupUiHelpers()
     if (auto* central = ui->centralwidget)
     {
         central->setAttribute(Qt::WA_StyledBackground, true);
-        central->setStyleSheet(QStringLiteral("QWidget#centralwidget{background:#f1f5f9;}"));
+        central->setStyleSheet(QStringLiteral("QWidget#centralwidget{background:#f5f6f8;}"));
     }
 
     m_galleryWidget = new SchemeGalleryWidget(this);
@@ -194,10 +194,10 @@ void MainWindow::setupUiHelpers()
                                           ? QStringLiteral("QLabel")
                                           : QStringLiteral("QLabel#%1").arg(title->objectName());
         QString style = QStringLiteral(
-            "%1{background:#ffffff;border:1px solid #d6e1f2;border-radius:14px;}"
-            "%2{font-size:15px;font-weight:600;color:#0f172a;padding:12px 16px;"
-            "background:#f8fafc;border-top-left-radius:14px;border-top-right-radius:14px;"
-            "border-bottom:1px solid #e2e8f0;}"
+            "%1{background:#ffffff;border:1px solid #e1e5ec;border-radius:12px;}"
+            "%2{font-size:18px;font-weight:600;color:#111827;padding:14px 18px;"
+            "background:#f9fafb;border-top-left-radius:12px;border-top-right-radius:12px;"
+            "border-bottom:1px solid #e1e5ec;}"
             "%3"
         ).arg(panelSelector, titleSelector, extraStyles);
         panel->setStyleSheet(style);
@@ -206,10 +206,10 @@ void MainWindow::setupUiHelpers()
     applyPanelCard(ui->navigationFrame, ui->navigationTitle,
                    QStringLiteral(
                        "QTreeWidget{border:none;background:transparent;padding:8px 12px;}"
-                       "QTreeWidget::item{padding:6px 4px;}"
-                       "QTreeWidget::item:hover{background:#f1f5f9;}"
-                       "QTreeWidget::item:selected{background:#e2e8f0;color:#0f172a;}"
-                       "QHeaderView::section{background:transparent;border:none;padding:4px 0;font-weight:600;color:#334155;}"
+                       "QTreeWidget::item{padding:6px 4px;font-size:13px;color:#374151;}"
+                       "QTreeWidget::item:hover{background:#eef2f6;}"
+                       "QTreeWidget::item:selected{background:#dbe3ee;color:#111827;}"
+                       "QHeaderView::section{background:transparent;border:none;padding:4px 0;font-weight:600;color:#1f2937;}"
                    ));
 
     applyPanelCard(ui->detailPanel, ui->detailTitle,
@@ -220,16 +220,16 @@ void MainWindow::setupUiHelpers()
 
     applyPanelCard(ui->vtkPanel, ui->vtkTitle,
                    QStringLiteral(
-                       "QFrame#vtkFrame{border:none;background:transparent;border-bottom-left-radius:14px;border-bottom-right-radius:14px;}"
-                       "QVTKOpenGLNativeWidget{border:none;border-bottom-left-radius:14px;border-bottom-right-radius:14px;}"
+                       "QFrame#vtkFrame{border:none;background:transparent;border-bottom-left-radius:12px;border-bottom-right-radius:12px;}"
+                       "QVTKOpenGLNativeWidget{border:none;border-bottom-left-radius:12px;border-bottom-right-radius:12px;}"
                    ));
 
     applyPanelCard(ui->logPanel, ui->logTitle);
 
     const QString splitterStyle = QStringLiteral(
-        "QSplitter::handle{background:#cbd5f5;}"
-        "QSplitter::handle:horizontal{width:8px;margin:0 4px;border-radius:4px;}"
-        "QSplitter::handle:vertical{height:8px;margin:4px 0;border-radius:4px;}"
+        "QSplitter::handle{background:#e2e5ec;}"
+        "QSplitter::handle:horizontal{width:6px;margin:0 3px;border-radius:3px;}"
+        "QSplitter::handle:vertical{height:6px;margin:3px 0;border-radius:3px;}"
     );
     ui->mainSplitter->setStyleSheet(splitterStyle);
     ui->contentSplitter->setStyleSheet(splitterStyle);
@@ -247,6 +247,25 @@ void MainWindow::setupUiHelpers()
     ui->contentSplitter->setStretchFactor(0, 0);
     ui->contentSplitter->setStretchFactor(1, 1);
     ui->contentSplitter->setCollapsible(1, true);
+    if (ui->contentSplitter)
+    {
+        QList<int> sizes = ui->contentSplitter->sizes();
+        bool invalid = sizes.size() < 2;
+        if (!invalid)
+        {
+            invalid = true;
+            for (int size : sizes)
+            {
+                if (size > 0)
+                {
+                    invalid = false;
+                    break;
+                }
+            }
+        }
+        if (invalid)
+            ui->contentSplitter->setSizes(defaultContentSplitterSizes());
+    }
     if (ui->visualizationSplitter)
     {
         ui->visualizationSplitter->setStretchFactor(0, 3);
@@ -255,8 +274,8 @@ void MainWindow::setupUiHelpers()
     }
 
     ui->logTextEdit->setStyleSheet(
-        "QPlainTextEdit{background:#0f172a;color:#f8fafc;border:none;"
-        "border-bottom-left-radius:14px;border-bottom-right-radius:14px;padding:12px;"
+        "QPlainTextEdit{background:#f8fafc;color:#1f2937;border:none;"
+        "border-bottom-left-radius:12px;border-bottom-right-radius:12px;padding:12px;"
         "font-family:\"JetBrains Mono\", \"Source Code Pro\", monospace;}"
     );
 
@@ -3625,16 +3644,42 @@ void MainWindow::setVisualizationVisible(bool visible)
 
         if (!m_lastSplitterSizes.isEmpty())
         {
-            ui->contentSplitter->setSizes(m_lastSplitterSizes);
+            QList<int> sizes = m_lastSplitterSizes;
+            bool invalid = sizes.size() < 2;
+            if (!invalid)
+            {
+                invalid = true;
+                for (int size : sizes)
+                {
+                    if (size > 0)
+                    {
+                        invalid = false;
+                        break;
+                    }
+                }
+            }
+            if (invalid)
+                sizes = defaultContentSplitterSizes();
+            ui->contentSplitter->setSizes(sizes);
         }
         else
         {
             QList<int> sizes = ui->contentSplitter->sizes();
-            if (sizes.size() < 2 || (sizes.at(0) == 0 && sizes.at(1) == 0))
+            bool invalid = sizes.size() < 2;
+            if (!invalid)
             {
-                sizes.clear();
-                sizes << 1 << 1;
+                invalid = true;
+                for (int size : sizes)
+                {
+                    if (size > 0)
+                    {
+                        invalid = false;
+                        break;
+                    }
+                }
             }
+            if (invalid)
+                sizes = defaultContentSplitterSizes();
             ui->contentSplitter->setSizes(sizes);
         }
 
@@ -3684,6 +3729,13 @@ void MainWindow::setVisualizationVisible(bool visible)
 
 void MainWindow::updateSelectionInfo(const QString& path, const QString& remark)
 {
+}
+
+QList<int> MainWindow::defaultContentSplitterSizes() const
+{
+    QList<int> sizes;
+    sizes << 360 << 840;
+    return sizes;
 }
 
 void MainWindow::appendLogMessage(const QString& message)


### PR DESCRIPTION
## Summary
- establish default splitter sizing so the parameter panel opens with a usable ratio
- refresh the parameter editor and related dialogs with a simplified color palette and consistent typography
- unify button styling across the parameter pages and scheme settings dialog for a minimal, cohesive look

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da49c63488832d8ef498b877dc0910