### PR TITLE
Add view control toolbar to VTK viewer

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -32,6 +32,8 @@ class QPushButton;
 class vtkGenericOpenGLRenderWindow;
 class vtkRenderer;
 class vtkActor;
+class vtkAxesActor;
+class vtkOrientationMarkerWidget;
 class QListWidgetItem;
 
 class MainWindow : public QMainWindow
@@ -320,6 +322,8 @@ private:
     vtkSmartPointer<vtkGenericOpenGLRenderWindow> m_renderWindow;
     vtkSmartPointer<vtkRenderer> m_renderer;
     vtkSmartPointer<vtkActor> m_currentActor;
+    vtkSmartPointer<vtkAxesActor> m_axesActor;
+    vtkSmartPointer<vtkOrientationMarkerWidget> m_orientationWidget;
     QList<int> m_lastSplitterSizes;
     bool m_visualizationVisible = false;
     QString m_materialsDbPath;

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -63,6 +63,12 @@ private slots:
     void on_syncMaterialsButton_clicked();
     void on_materialsListWidget_currentItemChanged(QListWidgetItem* current,
                                                    QListWidgetItem* previous);
+    void on_viewXYButton_clicked();
+    void on_viewYZButton_clicked();
+    void on_viewXZButton_clicked();
+    void on_viewIsoButton_clicked();
+    void on_rotateLeftButton_clicked();
+    void on_rotateRightButton_clicked();
 
 private:
     struct ModelRecord {
@@ -176,6 +182,8 @@ private:
     void appendLogMessage(const QString& message);
     void displayResultFile(const QString& filePath);
     void clearVtkScene();
+    void applyCameraView(const QVector3D& viewDirection, const QVector3D& viewUp);
+    void rotateCameraAroundFocal(double angleDegrees);
     void updateModelImagePreview(const ModelRecord* model);
     void refreshModelImagePreview();
     QString projectDisplayName() const;

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -62,9 +62,9 @@ private slots:
     void on_selectModelButton_clicked();
 
     void on_loadModelButton_clicked();
-    void on_syncMaterialsButton_clicked();
-    void on_materialsListWidget_currentItemChanged(QListWidgetItem* current,
-                                                   QListWidgetItem* previous);
+    void handleSyncMaterialsRequest();
+    void handleMaterialsSelectionChanged(QListWidgetItem* current,
+                                         QListWidgetItem* previous);
     void on_viewXYButton_clicked();
     void on_viewYZButton_clicked();
     void on_viewXZButton_clicked();

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -344,7 +344,7 @@
                  <item>
                   <widget class="QTabWidget" name="previewTabs">
                    <property name="currentIndex">
-                    <number>2</number>
+                    <number>0</number>
                    </property>
                    <widget class="QWidget" name="modelPreviewTab">
                     <attribute name="title">
@@ -416,21 +416,21 @@
                           <property name="toolTip">
                            <string>XY 俯视图</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_xy.svg</normaloff>:/icons/icons/view_xy.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/view_xy.svg</normaloff>:/icons/icons/view_xy.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -439,21 +439,21 @@
                           <property name="toolTip">
                            <string>YZ 侧视图</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_yz.svg</normaloff>:/icons/icons/view_yz.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/view_yz.svg</normaloff>:/icons/icons/view_yz.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -462,21 +462,21 @@
                           <property name="toolTip">
                            <string>XZ 正视图</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_xz.svg</normaloff>:/icons/icons/view_xz.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/view_xz.svg</normaloff>:/icons/icons/view_xz.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -485,21 +485,21 @@
                           <property name="toolTip">
                            <string>等轴测视图</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_iso.svg</normaloff>:/icons/icons/view_iso.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/view_iso.svg</normaloff>:/icons/icons/view_iso.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -508,21 +508,21 @@
                           <property name="toolTip">
                            <string>逆时针旋转</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/rotate_left.svg</normaloff>:/icons/icons/rotate_left.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/rotate_left.svg</normaloff>:/icons/icons/rotate_left.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>
@@ -531,21 +531,21 @@
                           <property name="toolTip">
                            <string>顺时针旋转</string>
                           </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/rotate_right.svg</normaloff>:/icons/icons/rotate_right.svg</iconset>
+                          </property>
                           <property name="iconSize">
                            <size>
                             <width>24</width>
                             <height>24</height>
                            </size>
                           </property>
-                          <property name="autoRaise">
-                           <bool>true</bool>
-                          </property>
-                          <property name="icon">
-                           <iconset resource="resources.qrc">
-                            <normaloff>:/icons/icons/rotate_right.svg</normaloff>:/icons/icons/rotate_right.svg</iconset>
-                          </property>
                           <property name="toolButtonStyle">
                            <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
                           </property>
                          </widget>
                         </item>

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -391,6 +391,181 @@
                       </layout>
                      </item>
                      <item>
+                      <widget class="QFrame" name="viewControlsFrame">
+                       <property name="frameShape">
+                        <enum>QFrame::NoFrame</enum>
+                       </property>
+                       <layout class="QHBoxLayout" name="viewControlsLayout">
+                        <property name="spacing">
+                         <number>6</number>
+                        </property>
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item>
+                         <widget class="QToolButton" name="viewXYButton">
+                          <property name="toolTip">
+                           <string>XY 俯视图</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_xy.svg</normaloff>:/icons/icons/view_xy.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QToolButton" name="viewYZButton">
+                          <property name="toolTip">
+                           <string>YZ 侧视图</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_yz.svg</normaloff>:/icons/icons/view_yz.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QToolButton" name="viewXZButton">
+                          <property name="toolTip">
+                           <string>XZ 正视图</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_xz.svg</normaloff>:/icons/icons/view_xz.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QToolButton" name="viewIsoButton">
+                          <property name="toolTip">
+                           <string>等轴测视图</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/view_iso.svg</normaloff>:/icons/icons/view_iso.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QToolButton" name="rotateLeftButton">
+                          <property name="toolTip">
+                           <string>逆时针旋转</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/rotate_left.svg</normaloff>:/icons/icons/rotate_left.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QToolButton" name="rotateRightButton">
+                          <property name="toolTip">
+                           <string>顺时针旋转</string>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>24</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="autoRaise">
+                           <bool>true</bool>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="resources.qrc">
+                            <normaloff>:/icons/icons/rotate_right.svg</normaloff>:/icons/icons/rotate_right.svg</iconset>
+                          </property>
+                          <property name="toolButtonStyle">
+                           <enum>Qt::ToolButtonIconOnly</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="viewControlsSpacer">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item>
                       <widget class="QFrame" name="vtkFrame">
                        <property name="frameShape">
                         <enum>QFrame::NoFrame</enum>

--- a/icons/rotate_left.svg
+++ b/icons/rotate_left.svg
@@ -1,3 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M12 5V2L7 6.5L12 11V8.1C14.873 8.1 17.2 10.427 17.2 13.3C17.2 16.173 14.873 18.5 12 18.5C9.127 18.5 6.8 16.173 6.8 13.3" stroke="#0f172a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="#e0f2fe"/>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <circle cx="12" cy="12" r="5.5" stroke="#0ea5e9" stroke-width="1.5" fill="none"/>
+  <path d="M12 6.3C9.4 6.3 7.3 8.4 7.3 11H5L7.8 14.2L10.6 11H8.7C8.7 9.1 10.1 7.7 12 7.7C13.9 7.7 15.3 9.1 15.3 11C15.3 12.9 13.9 14.3 12 14.3V15.8C14.7 15.8 16.8 13.7 16.8 11C16.8 8.3 14.7 6.3 12 6.3Z" fill="#0ea5e9"/>
+  <path d="M14.5 18.5L12 17L13 19.7L14.5 18.5Z" fill="#0ea5e9"/>
 </svg>

--- a/icons/rotate_left.svg
+++ b/icons/rotate_left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 5V2L7 6.5L12 11V8.1C14.873 8.1 17.2 10.427 17.2 13.3C17.2 16.173 14.873 18.5 12 18.5C9.127 18.5 6.8 16.173 6.8 13.3" stroke="#0f172a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="#e0f2fe"/>
+</svg>

--- a/icons/rotate_right.svg
+++ b/icons/rotate_right.svg
@@ -1,3 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M12 5V2L17 6.5L12 11V8.1C9.127 8.1 6.8 10.427 6.8 13.3C6.8 16.173 9.127 18.5 12 18.5C14.873 18.5 17.2 16.173 17.2 13.3" stroke="#0f172a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="#fef3c7"/>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <circle cx="12" cy="12" r="5.5" stroke="#0ea5e9" stroke-width="1.5" fill="none"/>
+  <path d="M12 6.3C14.6 6.3 16.7 8.4 16.7 11H19L16.2 14.2L13.4 11H15.3C15.3 9.1 13.9 7.7 12 7.7C10.1 7.7 8.7 9.1 8.7 11C8.7 12.9 10.1 14.3 12 14.3V15.8C9.3 15.8 7.2 13.7 7.2 11C7.2 8.3 9.3 6.3 12 6.3Z" fill="#0ea5e9"/>
+  <path d="M9.5 18.5L12 17L11 19.7L9.5 18.5Z" fill="#0ea5e9"/>
 </svg>

--- a/icons/rotate_right.svg
+++ b/icons/rotate_right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 5V2L17 6.5L12 11V8.1C9.127 8.1 6.8 10.427 6.8 13.3C6.8 16.173 9.127 18.5 12 18.5C14.873 18.5 17.2 16.173 17.2 13.3" stroke="#0f172a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="#fef3c7"/>
+</svg>

--- a/icons/view_iso.svg
+++ b/icons/view_iso.svg
@@ -1,5 +1,12 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="4" y="5" width="12" height="12" rx="2" stroke="#0f172a" stroke-width="1.5" fill="#dbeafe"/>
-  <path d="M10 5L18 9V19L10 15V5Z" fill="#a5b4fc" stroke="#3730a3" stroke-width="1.5" stroke-linejoin="round"/>
-  <path d="M4 17H12" stroke="#0f172a" stroke-width="1.5" stroke-linecap="round"/>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <path d="M8 8L16 6L18 14L10 16Z" fill="#e0f2fe" stroke="#0ea5e9" stroke-width="1"/>
+  <path d="M8 8L8 14L14 18L14 12L8 8Z" fill="#ecfccb" stroke="#84cc16" stroke-width="1"/>
+  <path d="M14 12L18 14L18 10L14 8L14 12Z" fill="#fee2e2" stroke="#f87171" stroke-width="1"/>
+  <line x1="11" y1="7" x2="11" y2="4" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M9.5 5.5L11 3L12.5 5.5Z" fill="#3b82f6"/>
+  <line x1="6" y1="13" x2="3" y2="13" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M4.5 11.5L2 13L4.5 14.5Z" fill="#ef4444"/>
+  <line x1="18" y1="19" x2="18" y2="22" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M16.5 20.5L18 23L19.5 20.5Z" fill="#22c55e"/>
 </svg>

--- a/icons/view_iso.svg
+++ b/icons/view_iso.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="5" width="12" height="12" rx="2" stroke="#0f172a" stroke-width="1.5" fill="#dbeafe"/>
+  <path d="M10 5L18 9V19L10 15V5Z" fill="#a5b4fc" stroke="#3730a3" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M4 17H12" stroke="#0f172a" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/icons/view_xy.svg
+++ b/icons/view_xy.svg
@@ -1,6 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
-  <path d="M7 7H17V11H7V7Z" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1"/>
-  <path d="M9 15L15 15" stroke="#1f2937" stroke-width="1.5" stroke-linecap="round"/>
-  <text x="6.5" y="20" font-family="Verdana" font-size="5" fill="#111827">XY</text>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <rect x="5" y="6" width="14" height="10" rx="2" fill="#e0f2fe" stroke="#0ea5e9" stroke-width="1"/>
+  <line x1="6" y1="15.5" x2="17" y2="15.5" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M16.5 13.5L19 15.5L16.5 17.5Z" fill="#ef4444"/>
+  <line x1="8.5" y1="8" x2="8.5" y2="18" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M6.5 8.5L8.5 6L10.5 8.5Z" fill="#22c55e"/>
+  <circle cx="15" cy="9" r="1.3" fill="#3b82f6"/>
+  <text x="6" y="21" font-family="Inter, Arial" font-size="5" font-weight="600" fill="#1f2937">XY</text>
 </svg>

--- a/icons/view_xy.svg
+++ b/icons/view_xy.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
+  <path d="M7 7H17V11H7V7Z" fill="#93c5fd" stroke="#1d4ed8" stroke-width="1"/>
+  <path d="M9 15L15 15" stroke="#1f2937" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="6.5" y="20" font-family="Verdana" font-size="5" fill="#111827">XY</text>
+</svg>

--- a/icons/view_xz.svg
+++ b/icons/view_xz.svg
@@ -1,6 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
-  <path d="M7 11H17" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M11 7V17" stroke="#a855f7" stroke-width="1.5" stroke-linecap="round"/>
-  <text x="6.8" y="20" font-family="Verdana" font-size="5" fill="#111827">XZ</text>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <rect x="6" y="8" width="12" height="8" rx="2" fill="#fee2e2" stroke="#f87171" stroke-width="1"/>
+  <line x1="7" y1="14.5" x2="17" y2="14.5" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M16.5 12.5L19 14.5L16.5 16.5Z" fill="#ef4444"/>
+  <line x1="15" y1="9" x2="15" y2="19" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M13 17.5L15 20L17 17.5Z" fill="#3b82f6"/>
+  <circle cx="9" cy="11" r="1.3" fill="#22c55e"/>
+  <text x="6" y="21" font-family="Inter, Arial" font-size="5" font-weight="600" fill="#1f2937">XZ</text>
 </svg>

--- a/icons/view_xz.svg
+++ b/icons/view_xz.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
+  <path d="M7 11H17" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M11 7V17" stroke="#a855f7" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="6.8" y="20" font-family="Verdana" font-size="5" fill="#111827">XZ</text>
+</svg>

--- a/icons/view_yz.svg
+++ b/icons/view_yz.svg
@@ -1,6 +1,10 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
-  <path d="M7 7H13V17H7V7Z" fill="#bbf7d0" stroke="#15803d" stroke-width="1"/>
-  <path d="M13 7H17V17H13" stroke="#166534" stroke-width="1.5"/>
-  <text x="6.8" y="20" font-family="Verdana" font-size="5" fill="#111827">YZ</text>
+  <rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#f8fafc" stroke="#cbd5f5" stroke-width="1"/>
+  <rect x="5" y="5" width="10" height="14" rx="2" fill="#ecfccb" stroke="#84cc16" stroke-width="1"/>
+  <line x1="13" y1="7" x2="20" y2="14" stroke="#3b82f6" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M18.5 14.2L20.5 16.7L18 16.9Z" fill="#3b82f6"/>
+  <line x1="8" y1="16" x2="8" y2="6" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M6 7.5L8 5L10 7.5Z" fill="#22c55e"/>
+  <circle cx="15.5" cy="9" r="1.3" fill="#ef4444"/>
+  <text x="6" y="21" font-family="Inter, Arial" font-size="5" font-weight="600" fill="#1f2937">YZ</text>
 </svg>

--- a/icons/view_yz.svg
+++ b/icons/view_yz.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="18" rx="4" stroke="#1f2937" stroke-width="1.5" fill="#f8fafc"/>
+  <path d="M7 7H13V17H7V7Z" fill="#bbf7d0" stroke="#15803d" stroke-width="1"/>
+  <path d="M13 7H17V17H13" stroke="#166534" stroke-width="1.5"/>
+  <text x="6.8" y="20" font-family="Verdana" font-size="5" fill="#111827">YZ</text>
+</svg>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1356,7 +1356,7 @@ QByteArray MainWindow::performPostRequest(const QUrl& url,
     return data;
 }
 
-void MainWindow::on_syncMaterialsButton_clicked()
+void MainWindow::handleSyncMaterialsRequest()
 {
     QList<QPushButton*> buttons;
     if (auto* clickedButton = qobject_cast<QPushButton*>(sender()))
@@ -1412,8 +1412,8 @@ void MainWindow::on_syncMaterialsButton_clicked()
     }
 }
 
-void MainWindow::on_materialsListWidget_currentItemChanged(QListWidgetItem* current,
-                                                           QListWidgetItem* previous)
+void MainWindow::handleMaterialsSelectionChanged(QListWidgetItem* current,
+                                                 QListWidgetItem* previous)
 {
     Q_UNUSED(previous);
     const QString key = current ? current->data(Qt::UserRole).toString() : QString();
@@ -2601,7 +2601,7 @@ void MainWindow::onTreeContextMenuRequested(const QPoint& pos)
         }
         else if (type == MaterialLibraryItem)
         {
-            menu.addAction(tr("同步材料数据"), this, &MainWindow::on_syncMaterialsButton_clicked);
+            menu.addAction(tr("同步材料数据"), this, &MainWindow::handleSyncMaterialsRequest);
         }
     }
 
@@ -3482,9 +3482,9 @@ QWidget* MainWindow::buildMaterialsSettingsWidget()
     layout->addWidget(frame, 1);
 
     connect(syncButton, &QPushButton::clicked,
-            this, &MainWindow::on_syncMaterialsButton_clicked);
+            this, &MainWindow::handleSyncMaterialsRequest);
     connect(list, &QListWidget::currentItemChanged,
-            this, &MainWindow::on_materialsListWidget_currentItemChanged);
+            this, &MainWindow::handleMaterialsSelectionChanged);
 
     m_materialsSettingsList = list;
     m_materialsSettingsStatusLabel = statusLabel;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2099,6 +2099,36 @@ void MainWindow::on_loadModelButton_clicked()
     displayResultFile(modelPath);
 }
 
+void MainWindow::on_viewXYButton_clicked()
+{
+    applyCameraView(QVector3D(0.0f, 0.0f, 1.0f), QVector3D(0.0f, 1.0f, 0.0f));
+}
+
+void MainWindow::on_viewYZButton_clicked()
+{
+    applyCameraView(QVector3D(1.0f, 0.0f, 0.0f), QVector3D(0.0f, 0.0f, 1.0f));
+}
+
+void MainWindow::on_viewXZButton_clicked()
+{
+    applyCameraView(QVector3D(0.0f, 1.0f, 0.0f), QVector3D(0.0f, 0.0f, 1.0f));
+}
+
+void MainWindow::on_viewIsoButton_clicked()
+{
+    applyCameraView(QVector3D(1.0f, 1.0f, 1.0f), QVector3D(0.0f, 0.0f, 1.0f));
+}
+
+void MainWindow::on_rotateLeftButton_clicked()
+{
+    rotateCameraAroundFocal(-30.0);
+}
+
+void MainWindow::on_rotateRightButton_clicked()
+{
+    rotateCameraAroundFocal(30.0);
+}
+
 void MainWindow::handleTreeSelectionChanged(QTreeWidgetItem* current, QTreeWidgetItem*)
 {
     if (!current)
@@ -6072,6 +6102,64 @@ void MainWindow::displayResultFile(const QString& filePath)
     m_renderer->ResetCamera();
     if (ui->vtkWidget && ui->vtkWidget->renderWindow())
         ui->vtkWidget->renderWindow()->Render();
+}
+
+void MainWindow::applyCameraView(const QVector3D& viewDirection, const QVector3D& viewUp)
+{
+    if (!m_renderer || !m_currentActor)
+        return;
+
+    vtkCamera* camera = m_renderer->GetActiveCamera();
+    if (!camera)
+        return;
+
+    double bounds[6];
+    m_currentActor->GetBounds(bounds);
+    const QVector3D center(float((bounds[0] + bounds[1]) * 0.5),
+                           float((bounds[2] + bounds[3]) * 0.5),
+                           float((bounds[4] + bounds[5]) * 0.5));
+    const double extentX = bounds[1] - bounds[0];
+    const double extentY = bounds[3] - bounds[2];
+    const double extentZ = bounds[5] - bounds[4];
+    const double radius = std::max({ extentX, extentY, extentZ, 1.0 });
+
+    QVector3D normalizedDir = viewDirection;
+    if (normalizedDir.lengthSquared() < 1e-6f)
+        normalizedDir = QVector3D(0.0f, 0.0f, 1.0f);
+    else
+        normalizedDir.normalize();
+
+    QVector3D normalizedUp = viewUp;
+    if (normalizedUp.lengthSquared() < 1e-6f)
+        normalizedUp = QVector3D(0.0f, 0.0f, 1.0f);
+    else
+        normalizedUp.normalize();
+
+    const QVector3D position = center + normalizedDir * float(radius * 2.5);
+
+    camera->SetFocalPoint(center.x(), center.y(), center.z());
+    camera->SetPosition(position.x(), position.y(), position.z());
+    camera->SetViewUp(normalizedUp.x(), normalizedUp.y(), normalizedUp.z());
+    camera->OrthogonalizeViewUp();
+    m_renderer->ResetCameraClippingRange();
+
+    if (ui->vtkWidget && ui->vtkWidget->renderWindow())
+        ui->vtkWidget->renderWindow()->Render();
+}
+
+void MainWindow::rotateCameraAroundFocal(double angleDegrees)
+{
+    if (!m_renderer || !m_currentActor)
+        return;
+
+    if (vtkCamera* camera = m_renderer->GetActiveCamera())
+    {
+        camera->Azimuth(angleDegrees);
+        camera->OrthogonalizeViewUp();
+        m_renderer->ResetCameraClippingRange();
+        if (ui->vtkWidget && ui->vtkWidget->renderWindow())
+            ui->vtkWidget->renderWindow()->Render();
+    }
 }
 
 void MainWindow::clearVtkScene()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -80,13 +80,16 @@
 
 #include <QVTKOpenGLNativeWidget.h>
 #include <vtkActor.h>
+#include <vtkAxesActor.h>
 #include <vtkCamera.h>
 #include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkNamedColors.h>
+#include <vtkOrientationMarkerWidget.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkOBJReader.h>
 #include <vtkSTLReader.h>
 #include <QSettings>
@@ -358,6 +361,22 @@ void MainWindow::setupUiHelpers()
     m_renderer->SetBackground(colors->GetColor3d("AliceBlue").GetData());
     m_renderWindow->AddRenderer(m_renderer);
     ui->vtkWidget->setRenderWindow(m_renderWindow);
+
+    if (!m_axesActor)
+        m_axesActor = vtkSmartPointer<vtkAxesActor>::New();
+    if (!m_orientationWidget)
+        m_orientationWidget = vtkSmartPointer<vtkOrientationMarkerWidget>::New();
+    auto* interactor = ui->vtkWidget->interactor();
+    if (!interactor && ui->vtkWidget->renderWindow())
+        interactor = ui->vtkWidget->renderWindow()->GetInteractor();
+    if (interactor)
+    {
+        m_orientationWidget->SetOrientationMarker(m_axesActor);
+        m_orientationWidget->SetInteractor(interactor);
+        m_orientationWidget->SetViewport(0.0, 0.0, 0.2, 0.2);
+        m_orientationWidget->SetEnabled(1);
+        m_orientationWidget->InteractiveOff();
+    }
 
     if (ui->materialPropertiesTable)
     {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -366,9 +366,9 @@ void MainWindow::setupUiHelpers()
         m_axesActor = vtkSmartPointer<vtkAxesActor>::New();
     if (!m_orientationWidget)
         m_orientationWidget = vtkSmartPointer<vtkOrientationMarkerWidget>::New();
-    auto* interactor = ui->vtkWidget->interactor();
-    if (!interactor && ui->vtkWidget->renderWindow())
-        interactor = ui->vtkWidget->renderWindow()->GetInteractor();
+    QVTKInteractor * interactor = ui->vtkWidget->interactor();
+//    if (!interactor && ui->vtkWidget->renderWindow())
+//        interactor = ui->vtkWidget->renderWindow()->GetInteractor();
     if (interactor)
     {
         m_orientationWidget->SetOrientationMarker(m_axesActor);

--- a/resources.qrc
+++ b/resources.qrc
@@ -9,5 +9,11 @@
         <file>icons/materials.svg</file>
         <file>icons/plan.svg</file>
         <file>icons/model.svg</file>
+        <file>icons/view_xy.svg</file>
+        <file>icons/view_yz.svg</file>
+        <file>icons/view_xz.svg</file>
+        <file>icons/view_iso.svg</file>
+        <file>icons/rotate_left.svg</file>
+        <file>icons/rotate_right.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
## Summary
- add a row of toolbar buttons with icons above the VTK viewport for XY/YZ/XZ/isometric/rotation controls
- register the new SVG icons in the resource file so they can be used in the UI
- implement camera helper routines that the new buttons use to orient or rotate the renderer

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c7f0a8188832da090b4917337eca8)