### PR TITLE
Fix thumbnail aspect ratio and prevent layout expansion

### DIFF
--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -11,6 +11,7 @@
 #include <QGraphicsDropShadowEffect>
 #include <QColor>
 #include <QIcon>
+#include <QPainter>
 
 SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     : QFrame(parent), m_id(id)
@@ -82,7 +83,7 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     m_imageLabel = new QLabel(this);
     m_imageLabel->setObjectName("imageLabel");
     m_imageLabel->setMinimumSize(220,160);
-    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     m_imageLabel->setAlignment(Qt::AlignCenter);
     m_imageLabel->setWordWrap(true);
     m_imageLabel->setText(tr("暂无封面"));
@@ -172,6 +173,14 @@ void SchemeCardWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 void SchemeCardWidget::resizeEvent(QResizeEvent* ev)
 {
     QFrame::resizeEvent(ev);
+    if (m_imageLabel) {
+        const int labelWidth = m_imageLabel->width();
+        if (labelWidth > 0) {
+            const qreal aspect = 220.0 / 160.0;
+            const int targetHeight = qMax(160, qRound(labelWidth / aspect));
+            m_imageLabel->setFixedHeight(targetHeight);
+        }
+    }
     updateThumbnailDisplay();
 }
 
@@ -194,10 +203,20 @@ void SchemeCardWidget::updateThumbnailDisplay()
 
     const qreal ratio = devicePixelRatioF();
     const QSize targetSize = (QSizeF(labelSize) * ratio).toSize();
-    QPixmap scaled = m_thumbnail.scaled(targetSize, Qt::KeepAspectRatio,
-                                        Qt::SmoothTransformation);
-    scaled.setDevicePixelRatio(ratio);
-    m_imageLabel->setPixmap(scaled);
+    QPixmap canvas(targetSize);
+    canvas.setDevicePixelRatio(ratio);
+    canvas.fill(Qt::transparent);
+
+    const QPixmap scaled = m_thumbnail.scaled(targetSize, Qt::KeepAspectRatio,
+                                              Qt::SmoothTransformation);
+    QPainter painter(&canvas);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    const QPoint topLeft((targetSize.width() - scaled.width()) / 2,
+                         (targetSize.height() - scaled.height()) / 2);
+    painter.drawPixmap(topLeft, scaled);
+    painter.end();
+
+    m_imageLabel->setPixmap(canvas);
 }
 
 

--- a/SchemeCardWidget.cpp
+++ b/SchemeCardWidget.cpp
@@ -11,7 +11,6 @@
 #include <QGraphicsDropShadowEffect>
 #include <QColor>
 #include <QIcon>
-#include <QPainter>
 
 SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
     : QFrame(parent), m_id(id)
@@ -82,8 +81,8 @@ SchemeCardWidget::SchemeCardWidget(const QString& id, QWidget* parent)
 
     m_imageLabel = new QLabel(this);
     m_imageLabel->setObjectName("imageLabel");
-    m_imageLabel->setMinimumSize(220,160);
-    m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_imageLabel->setFixedSize(220,160);
+    m_imageLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_imageLabel->setAlignment(Qt::AlignCenter);
     m_imageLabel->setWordWrap(true);
     m_imageLabel->setText(tr("暂无封面"));
@@ -173,14 +172,6 @@ void SchemeCardWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 void SchemeCardWidget::resizeEvent(QResizeEvent* ev)
 {
     QFrame::resizeEvent(ev);
-    if (m_imageLabel) {
-        const int labelWidth = m_imageLabel->width();
-        if (labelWidth > 0) {
-            const qreal aspect = 220.0 / 160.0;
-            const int targetHeight = qMax(160, qRound(labelWidth / aspect));
-            m_imageLabel->setFixedHeight(targetHeight);
-        }
-    }
     updateThumbnailDisplay();
 }
 
@@ -203,20 +194,10 @@ void SchemeCardWidget::updateThumbnailDisplay()
 
     const qreal ratio = devicePixelRatioF();
     const QSize targetSize = (QSizeF(labelSize) * ratio).toSize();
-    QPixmap canvas(targetSize);
-    canvas.setDevicePixelRatio(ratio);
-    canvas.fill(Qt::transparent);
-
-    const QPixmap scaled = m_thumbnail.scaled(targetSize, Qt::KeepAspectRatio,
-                                              Qt::SmoothTransformation);
-    QPainter painter(&canvas);
-    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
-    const QPoint topLeft((targetSize.width() - scaled.width()) / 2,
-                         (targetSize.height() - scaled.height()) / 2);
-    painter.drawPixmap(topLeft, scaled);
-    painter.end();
-
-    m_imageLabel->setPixmap(canvas);
+    QPixmap scaled = m_thumbnail.scaled(targetSize, Qt::KeepAspectRatio,
+                                        Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(ratio);
+    m_imageLabel->setPixmap(scaled);
 }
 
 


### PR DESCRIPTION
### Motivation
- Wide or oddly proportioned thumbnail images were allowing the card to expand horizontally and affect layout sizes. 
- The intent is to ensure thumbnails display at a consistent aspect ratio without driving widget size hints. 

### Description
- Modified `SchemeCardWidget.cpp` to set the thumbnail label `m_imageLabel` vertical policy to `QSizePolicy::Fixed` while keeping horizontal growth with `QSizePolicy::Expanding`.
- Added a `resizeEvent` adjustment that enforces a target height derived from a fixed aspect (`220/160`) and a minimum height of `160` using `m_imageLabel->setFixedHeight()`.
- Reworked `updateThumbnailDisplay()` to render the scaled thumbnail into a fixed-size transparent `QPixmap` canvas (using `devicePixelRatioF()` and `QPainter`) and center the image so wide images no longer change layout hints.
- Added `#include <QPainter>` to support canvas painting.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f619cc0a4832d859b01f1460385ab)